### PR TITLE
Fix release build on windows

### DIFF
--- a/crates/hbc-decomp/build.rs
+++ b/crates/hbc-decomp/build.rs
@@ -50,12 +50,11 @@ fn main() {
     .unwrap();
     writeln!(out_file, "    match version {{").unwrap();
     for version in &versions {
-        let file_name = format!("Bytecode{version}.json");
-        let rel_path = Path::new("resources").join("bytecode").join(file_name);
+        let rel_path = format!("resources/bytecode/Bytecode{version}.json");
         writeln!(
             out_file,
             "        {version} => Some(include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/\", \"{}\"))),",
-            rel_path.display()
+            rel_path
         )
         .unwrap();
     }


### PR DESCRIPTION
The release build on windows failed, because path.display() includes non-escaped backslashes, which led to unknown character escape errors:

```
error: unknown character escape: `b`
 --> C:\...\hermes-decomp\target\release\build\hbc-decomp-266f6746ffd75056\out/bytecode_formats.rs:7:85
  |
7 |         40 => Some(include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/", "resources\bytecode\Bytecode40.json"))),
  |                                                                                     ^ unknown character escape
```
