### PR TITLE
Fix Windows release build and add cross-platform CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build release binaries
+        run: cargo build --release --workspace
+
+      - name: Collect binaries (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp target/release/hermes-decomp dist/
+          cp target/release/hermes-mcp dist/
+
+      - name: Collect binaries (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp target/release/hermes-decomp.exe dist/
+          cp target/release/hermes-mcp.exe dist/
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: hermes-decomp-${{ matrix.target }}
+          path: dist/*
+          if-no-files-found: error

--- a/crates/hbc-decomp/build.rs
+++ b/crates/hbc-decomp/build.rs
@@ -50,12 +50,14 @@ fn main() {
     .unwrap();
     writeln!(out_file, "    match version {{").unwrap();
     for version in &versions {
-        let file_name = format!("Bytecode{version}.json");
-        let rel_path = Path::new("resources").join("bytecode").join(file_name);
+        // Use forward slashes: this string is embedded into an include_str! literal,
+        // and a backslash path (from Path::join on Windows) would create invalid
+        // escape sequences such as `\b` in the generated source file.
+        let rel_path = format!("resources/bytecode/Bytecode{version}.json");
         writeln!(
             out_file,
             "        {version} => Some(include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/\", \"{}\"))),",
-            rel_path.display()
+            rel_path
         )
         .unwrap();
     }


### PR DESCRIPTION
build.rs embedded resource paths into include_str! literals using Path::join, which produces backslash separators on Windows. The generated source then contained invalid escape sequences such as `\b`, breaking the release build. Use forward-slash paths, which include_str! accepts on every platform.

Add a GitHub Actions workflow that builds the release binaries (hermes-decomp, hermes-mcp) on Linux, macOS, and Windows and uploads them as artifacts, so the Windows build is verified automatically.

Credits
- Reported by @GabSouzaGit (#2)
- Fix originally proposed by @mtfwvi (#1) | Same approach, both are credited via Co-authored-by on the fix commit.