### PR TITLE
Fix v96 debug-info crash, harden the parser, and add a side-by-side diff TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,6 @@ dependencies = [
  "crossterm",
  "env_logger",
  "hbc-decomp",
- "libc",
  "log",
  "ratatui",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,10 +113,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bitflags"
-version = "2.10.0"
+name = "bit-set"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -101,16 +155,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -136,6 +196,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -182,7 +248,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -208,15 +274,25 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.7.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
  "itoa",
+ "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -224,6 +300,21 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -252,15 +343,17 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "crossterm_winapi",
- "libc",
- "mio 0.8.11",
+ "derive_more",
+ "document-features",
+ "mio",
  "parking_lot",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -276,13 +369,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -296,7 +419,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -305,9 +441,73 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -362,10 +562,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fnv"
@@ -375,9 +623,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "futures"
@@ -435,7 +683,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -469,10 +717,54 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.15.5"
+name = "generic-array"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -500,6 +792,7 @@ dependencies = [
  "crossterm",
  "env_logger",
  "hbc-decomp",
+ "libc",
  "log",
  "ratatui",
  "regex",
@@ -524,6 +817,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
@@ -556,6 +855,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,18 +884,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -606,7 +918,7 @@ checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -620,10 +932,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -642,11 +1004,21 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -656,16 +1028,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
-name = "mio"
-version = "0.8.11"
+name = "memmem"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.48.0",
+ "autocfg",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -674,8 +1055,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -685,6 +1107,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -698,6 +1129,39 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "parking_lot"
@@ -729,6 +1193,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +1315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,22 +1339,130 @@ dependencies = [
 ]
 
 [[package]]
-name = "ratatui"
-version = "0.26.3"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44c9e68fd46eda15c646fbb85e1040b657a58cdc8c98db1d97a55930d991eef"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "bitflags",
- "cassowary",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
+dependencies = [
+ "bitflags 2.13.0",
  "compact_str",
- "crossterm",
- "itertools 0.12.1",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
  "lru",
- "paste",
- "stability",
+ "palette",
+ "serde",
  "strum",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
+ "indoc",
+ "instability",
+ "itertools",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
+ "strum",
+ "time",
+ "unicode-segmentation",
  "unicode-width",
 ]
 
@@ -819,7 +1492,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -839,7 +1512,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -886,7 +1559,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
  "tracing",
@@ -898,11 +1571,33 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01263441d3f8635c628e33856c468b96ebbce1af2d3699ea712ca71432d4ee7a"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -940,7 +1635,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -948,6 +1643,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -976,7 +1677,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -987,7 +1688,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1001,6 +1702,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1026,7 +1738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
- "mio 0.8.11",
+ "mio",
  "signal-hook",
 ]
 
@@ -1045,6 +1757,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1069,16 +1787,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stability"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d904e7009df136af5297832a3ace3370cd14ff1546a232f4f185036c2736fcac"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,24 +1800,34 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1124,12 +1842,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1140,8 +1954,29 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tokio"
@@ -1151,7 +1986,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.1.1",
+ "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -1168,7 +2003,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1203,7 +2038,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1214,6 +2049,18 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -1229,20 +2076,20 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.13.0",
+ "itertools",
  "unicode-segmentation",
  "unicode-width",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"
@@ -1251,10 +2098,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1288,7 +2171,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -1299,6 +2182,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -1344,7 +2299,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1355,7 +2310,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1384,20 +2339,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1411,41 +2357,20 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1455,21 +2380,9 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1485,21 +2398,9 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1509,27 +2410,21 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zmij"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,28 @@
 # Hermes Bytecode Decompiler
 
+[![Build](https://github.com/SymbioticSec/hermes-decomp/actions/workflows/build.yml/badge.svg)](https://github.com/SymbioticSec/hermes-decomp/actions/workflows/build.yml)
+
 A Rust-based decompiler for Hermes bytecode files (`.hbc`), the JavaScript engine used by React Native applications.
 
 ## Installation
 
-### Prerequisites
+### Download pre-built binaries
+
+Every push is built automatically by GitHub Actions for **Linux**, **macOS** (Apple Silicon), and **Windows**.
+Grab the latest binaries (`hermes-decomp` and the `hermes-mcp` server) from the
+[Actions tab](https://github.com/SymbioticSec/hermes-decomp/actions/workflows/build.yml):
+open the most recent successful run and download the artifact for your platform:
+
+- `hermes-decomp-x86_64-unknown-linux-gnu`
+- `hermes-decomp-aarch64-apple-darwin`
+- `hermes-decomp-x86_64-pc-windows-msvc`
+
+### Build from Source
+
+#### Prerequisites
 
 - Rust 1.70 or later
 - Cargo (comes with Rust)
-
-### Build from Source
 
 ```bash
 git clone https://github.com/SymbioticSec/hermes-decomp.git
@@ -17,7 +30,7 @@ cd hermes-decomp
 cargo build --release
 ```
 
-The binary will be at `target/release/hermes-decomp`.
+The binaries will be at `target/release/hermes-decomp` and `target/release/hermes-mcp`.
 
 ## Usage
 
@@ -42,17 +55,21 @@ hermes-decomp disasm app.hbc --function 5 --output disasm.txt
 ![Disassembly Example](disasm.png)
 
 **3. Decompile**
-Two decompile commands are available: `decompile` (legacy) and `decompile` (advanced, recommended).
-Both share the same options.
+Lift bytecode into readable JavaScript (with control-flow recovery, naming, and ESM output for Metro bundles).
 ```bash
 hermes-decomp decompile app.hbc --output decompiled.js
-hermes-decomp decompile app.hbc --function 5
 hermes-decomp decompile app.hbc --function 5
 # Options:
 #   --resolve-closures    Closure resolution across functions (auto-enabled when decompiling all)
 #   --expand              Inline referenced functions
 #   --expand-depth N      Expansion depth (default: 2)
 #   --show-offsets        Include bytecode offsets as comments
+#   --no-strings          Don't resolve string IDs
+#   --no-propagate        Disable constant/copy propagation
+#   --no-simplify         Disable expression simplification
+#   --no-structure        Disable if/while/for reconstruction
+#   --check-dead-code     Report functions unreachable from Metro roots
+#   --assembly            Binary Ninja-style output with absolute offsets
 #   --json                Export IR as JSON instead of JS
 ```
 
@@ -237,6 +254,20 @@ Hermes is a JavaScript engine optimized for React Native. Unlike V8 or JSC which
     *   **Structure Recovery**: Reconstructing `if`, `while`, `for` loops from graph edges.
     *   **Pattern Matching**: Detecting `class`, `async`, `generator` state machines.
 5.  **Code Generation**: The optimized IR is converted back into valid JavaScript syntax.
+
+## Contributing
+
+Contributions are welcome!
+
+**Please open an issue first** before submitting a pull request. This lets us discuss the
+problem or feature, avoid duplicate work, and agree on an approach before any code is written.
+
+1. [Open an issue](https://github.com/SymbioticSec/hermes-decomp/issues/new) describing the bug or feature.
+2. Wait for feedback / confirmation that a PR is welcome.
+3. Fork the repo and create a branch from `main`.
+4. Make your change and ensure `cargo build --release --workspace` and `cargo test --workspace` pass.
+   The CI builds on Linux, macOS, and Windows — keep all three green.
+5. Open a pull request that references the issue.
 
 ## Resources
 

--- a/crates/hbc-decomp-cli/Cargo.toml
+++ b/crates/hbc-decomp-cli/Cargo.toml
@@ -20,6 +20,3 @@ serde_json = "1.0"
 log = "0.4.29"
 env_logger = "0.11.9"
 similar = "2.7.0"
-
-[target.'cfg(unix)'.dependencies]
-libc = "0.2"

--- a/crates/hbc-decomp-cli/Cargo.toml
+++ b/crates/hbc-decomp-cli/Cargo.toml
@@ -13,10 +13,13 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.0", features = ["derive"] }
 hbc-decomp = { path = "../hbc-decomp" }
-ratatui = "0.26.3"
-crossterm = "0.27.0"
+ratatui = "0.30"
+crossterm = "0.29"
 regex = "1.10"
 serde_json = "1.0"
 log = "0.4.29"
 env_logger = "0.11.9"
 similar = "2.7.0"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/crates/hbc-decomp-cli/src/main.rs
+++ b/crates/hbc-decomp-cli/src/main.rs
@@ -12,6 +12,10 @@ use helpers::{load_file, load_format, write_output};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
+    // Give Rayon workers a large stack up front: decompilation recurses deeply
+    // and the default stack overflows on big bundles (e.g. `decompile
+    // --resolve-closures` on a multi-MB Metro bundle).
+    hbc_decomp::configure_thread_pool();
     let cli = Cli::parse();
 
     match cli.command {

--- a/crates/hbc-decomp-cli/src/main.rs
+++ b/crates/hbc-decomp-cli/src/main.rs
@@ -10,7 +10,24 @@ mod tui;
 use cli_args::{Cli, Command};
 use helpers::{load_file, load_format, write_output};
 
+/// Restore the default SIGPIPE behavior on Unix. Rust ignores SIGPIPE by
+/// default, which turns a closed output pipe (e.g. `… | head`) into a
+/// "Broken pipe" panic instead of a clean exit. Resetting to SIG_DFL makes the
+/// tool terminate silently like `cat`/`grep` when the reader goes away.
+#[cfg(unix)]
+fn reset_sigpipe() {
+    // SAFETY: a single libc::signal call with valid constants, before threads
+    // that touch stdout are spawned.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    reset_sigpipe();
     env_logger::init();
     // Give Rayon workers a large stack up front: decompilation recurses deeply
     // and the default stack overflows on big bundles (e.g. `decompile

--- a/crates/hbc-decomp-cli/src/main.rs
+++ b/crates/hbc-decomp-cli/src/main.rs
@@ -10,24 +10,7 @@ mod tui;
 use cli_args::{Cli, Command};
 use helpers::{load_file, load_format, write_output};
 
-/// Restore the default SIGPIPE behavior on Unix. Rust ignores SIGPIPE by
-/// default, which turns a closed output pipe (e.g. `… | head`) into a
-/// "Broken pipe" panic instead of a clean exit. Resetting to SIG_DFL makes the
-/// tool terminate silently like `cat`/`grep` when the reader goes away.
-#[cfg(unix)]
-fn reset_sigpipe() {
-    // SAFETY: a single libc::signal call with valid constants, before threads
-    // that touch stdout are spawned.
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
-    }
-}
-
-#[cfg(not(unix))]
-fn reset_sigpipe() {}
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    reset_sigpipe();
     env_logger::init();
     // Give Rayon workers a large stack up front: decompilation recurses deeply
     // and the default stack overflows on big bundles (e.g. `decompile

--- a/crates/hbc-decomp-cli/src/tui/app.rs
+++ b/crates/hbc-decomp-cli/src/tui/app.rs
@@ -1,12 +1,14 @@
+use ratatui::layout::Rect;
 use ratatui::text::Text;
 use ratatui::widgets::ListState;
 use std::collections::{HashMap, HashSet};
 use std::sync::{mpsc::Receiver, Arc};
 use std::time::Instant;
 
-use hbc_decomp::{BytecodeFile, BytecodeFormat, ClosureContext, PipelineContext};
+use hbc_decomp::{BytecodeFile, BytecodeFormat, PipelineContext};
 
 use super::debug_log;
+use super::gitdiff::{self, GitDiffJob, GitMsg, GitRow};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ViewMode {
@@ -77,12 +79,6 @@ pub struct App {
     pub disasm_cache2: HashMap<usize, Text<'static>>,
     pub decompile_cache2: HashMap<usize, String>,
 
-    // Optional closure contexts for higher-quality v2 pseudocode.
-    pub closure_ctx: Option<ClosureContext>,
-    pub closure_ctx2: Option<ClosureContext>,
-    pub closure_ctx_attempted: bool,
-    pub closure_ctx2_attempted: bool,
-
     // Diff status for each function (by name)
     pub diff_status: HashMap<String, DiffStatus>,
     pub diff_rx: Option<Receiver<DiffProgressMsg>>,
@@ -97,11 +93,43 @@ pub struct App {
     // Toggle for content diff highlighting
     pub show_diff_colors: bool,
 
-    // Toggle for the unified (git-style, single column) diff view.
-    pub diff_unified: bool,
+    // Full-program "git" diff mode: hides the function list and shows all code
+    // of file 1 (left) vs file 2 (right), aligned. Computed off-thread.
+    pub git_diff: bool,
+    pub git_rows: Arc<Vec<GitRow>>,
+    pub git_rx: Option<Receiver<GitMsg>>,
+    pub git_computing: bool,
+    pub git_progress: (usize, usize),
+    pub git_built_kind: Option<ViewMode>,
+    // Git-diff content kind. Defaults to Disasm: it needs no decompiler pipeline
+    // so it shows instantly; `v` switches to Decompile (which waits for the
+    // pipeline). Independent from the split-view `diff_kind`.
+    pub git_kind: ViewMode,
+    // Ignore volatile Metro ids (module_955 vs module_769) in the git diff.
+    pub git_normalize: bool,
+    // In-view search for the git diff.
+    pub git_search: String,
+    pub git_searching: bool,
+    pub git_match_count: usize,
+    // 1-based index of the match the view is currently on (0 = none).
+    pub git_match_index: usize,
+    // Syntax-highlight the code in the git diff (vs. plain diff tint).
+    pub git_syntax: bool,
+    // Collapsed functions (by their header index in git_rows).
+    pub git_folded: std::collections::HashSet<usize>,
+    // Display order: indices into git_rows that are currently visible (respects
+    // folds). `scroll` indexes into this, not git_rows directly.
+    pub git_visible: Vec<usize>,
+    // Inner area of the git columns (set during draw) for click-to-fold.
+    pub git_view_top: u16,
+    pub git_view_height: u16,
+    // Frame counter, advanced each loop, for animating the loading spinner.
+    pub tick: usize,
 
     // Persistent list state for function list scrolling
     pub list_state: ListState,
+    // Inner area of the function list (set during draw), for click-to-select.
+    pub list_inner: Rect,
 
     // Full pipeline context (IPA, Metro, naming) — built in background
     pub pipeline_ctx: Option<Arc<PipelineContext>>,
@@ -198,10 +226,6 @@ impl App {
             decompile_cache: HashMap::new(),
             disasm_cache2: HashMap::new(),
             decompile_cache2: HashMap::new(),
-            closure_ctx: None,
-            closure_ctx2: None,
-            closure_ctx_attempted: false,
-            closure_ctx2_attempted: false,
             diff_status: HashMap::new(),
             diff_rx: None,
             diff_analyzing: false,
@@ -214,8 +238,28 @@ impl App {
                 DiffMode::Assembly
             },
             show_diff_colors: true, // Default to true as user requested colors
-            diff_unified: false,
+            git_diff: false,
+            git_rows: Arc::new(Vec::new()),
+            git_rx: None,
+            git_computing: false,
+            git_progress: (0, 0),
+            git_built_kind: None,
+            // Decompiled by default — it streams per function now, so there's
+            // no opaque wait; `v` toggles to disassembly.
+            git_kind: ViewMode::Decompile,
+            git_normalize: true,
+            git_search: String::new(),
+            git_searching: false,
+            git_match_count: 0,
+            git_match_index: 0,
+            git_syntax: false,
+            git_folded: std::collections::HashSet::new(),
+            git_visible: Vec::new(),
+            git_view_top: 0,
+            git_view_height: 0,
+            tick: 0,
             list_state: ListState::default().with_selected(Some(0)),
+            list_inner: Rect::default(),
             pipeline_ctx: None,
             pipeline_rx: None,
             pipeline_building: false,
@@ -260,58 +304,44 @@ impl App {
             app.known_names = app.all_function_names.iter().cloned().collect();
         }
 
-        // Spawn background pipeline build (IPA, Metro, naming) for file 1
-        {
-            let file = app.file.clone();
-            let format = app.format.clone();
-            let (tx, rx) = std::sync::mpsc::channel();
-            app.pipeline_rx = Some(rx);
-            app.pipeline_building = true;
-            std::thread::spawn(move || {
-                debug_log("[TUI] Pipeline build (file 1) started...");
-                let start = Instant::now();
-                match PipelineContext::build(&file, &format) {
-                    Ok(ctx) => {
-                        debug_log(&format!(
-                            "[TUI] Pipeline build (file 1) done in {:.2?}",
-                            start.elapsed()
-                        ));
-                        let _ = tx.send(ctx);
-                    }
-                    Err(e) => {
-                        debug_log(&format!("[TUI] Pipeline build (file 1) failed: {e}"));
-                    }
-                }
-            });
-        }
-
-        // Spawn background pipeline build for file 2 (diff mode)
-        if let (Some(file2), Some(format2)) = (&app.file2, &app.format2) {
-            let file2 = file2.clone();
-            let format2 = format2.clone();
-            let (tx, rx) = std::sync::mpsc::channel();
-            app.pipeline_rx2 = Some(rx);
-            app.pipeline_building2 = true;
-            std::thread::spawn(move || {
-                debug_log("[TUI] Pipeline build (file 2) started...");
-                let start = Instant::now();
-                match PipelineContext::build(&file2, &format2) {
-                    Ok(ctx) => {
-                        debug_log(&format!(
-                            "[TUI] Pipeline build (file 2) done in {:.2?}",
-                            start.elapsed()
-                        ));
-                        let _ = tx.send(ctx);
-                    }
-                    Err(e) => {
-                        debug_log(&format!("[TUI] Pipeline build (file 2) failed: {e}"));
-                    }
-                }
-            });
-        }
-
+        // The decompiler pipeline (IPA, Metro, naming) is built lazily — it
+        // takes several seconds per file and would otherwise saturate all CPU
+        // cores at startup, starving the (instant) disassembly views and making
+        // the UI lag. It's kicked off the first time decompiled output is asked
+        // for (Decompile view, or the git diff's `v`).
         debug_log(&format!("[TUI] App::new done in {:.2?}", total_start.elapsed()));
         app
+    }
+
+    /// Start building the decompiler pipeline context(s) in the background, if
+    /// not already built or in progress. Idempotent.
+    pub fn ensure_pipeline_building(&mut self) {
+        if self.pipeline_ctx.is_none() && !self.pipeline_building {
+            let file = self.file.clone();
+            let format = self.format.clone();
+            let (tx, rx) = std::sync::mpsc::channel();
+            self.pipeline_rx = Some(rx);
+            self.pipeline_building = true;
+            std::thread::spawn(move || match PipelineContext::build(&file, &format) {
+                Ok(ctx) => {
+                    let _ = tx.send(ctx);
+                }
+                Err(e) => debug_log(&format!("[pipeline] file 1 build failed: {e}")),
+            });
+        }
+        if let (Some(file2), Some(format2)) = (self.file2.clone(), self.format2.clone()) {
+            if self.pipeline_ctx2.is_none() && !self.pipeline_building2 {
+                let (tx, rx) = std::sync::mpsc::channel();
+                self.pipeline_rx2 = Some(rx);
+                self.pipeline_building2 = true;
+                std::thread::spawn(move || match PipelineContext::build(&file2, &format2) {
+                    Ok(ctx) => {
+                        let _ = tx.send(ctx);
+                    }
+                    Err(e) => debug_log(&format!("[pipeline] file 2 build failed: {e}")),
+                });
+            }
+        }
     }
 
     // calculate_diff_status method removed (moved to module)
@@ -382,6 +412,20 @@ impl App {
         None
     }
 
+    /// Select the function clicked at the given terminal cell, if it falls
+    /// inside the function list.
+    pub fn select_at_row(&mut self, col: u16, row: u16) {
+        let a = self.list_inner;
+        let inside = col >= a.x && col < a.x + a.width && row >= a.y && row < a.y + a.height;
+        if !inside {
+            return;
+        }
+        let idx = self.list_state.offset() + (row - a.y) as usize;
+        if idx < self.function_names.len() {
+            self.set_selected(idx);
+        }
+    }
+
     pub fn set_selected(&mut self, index: usize) {
         if self.selected != index {
             self.selected = index;
@@ -412,6 +456,159 @@ impl App {
                 _ => ViewMode::Disasm,
             };
             self.scroll = 0;
+        }
+    }
+
+    /// Drop the cached git-diff rows (e.g. after switching disasm/decompile),
+    /// so the next `request_git_diff` recomputes.
+    pub fn invalidate_git_diff(&mut self) {
+        self.git_rows = Arc::new(Vec::new());
+        self.git_built_kind = None;
+        self.git_rx = None;
+        self.git_computing = false;
+        self.git_progress = (0, 0);
+        self.git_folded.clear();
+        self.git_visible.clear();
+    }
+
+    /// Recompute which git_rows are visible given the current fold state. Folded
+    /// functions show only their header; their body rows are hidden.
+    pub fn rebuild_git_visible(&mut self) {
+        let mut visible = Vec::with_capacity(self.git_rows.len());
+        let mut hiding = false;
+        for (i, row) in self.git_rows.iter().enumerate() {
+            match row {
+                GitRow::Header(_) => {
+                    hiding = self.git_folded.contains(&i);
+                    visible.push(i);
+                }
+                _ => {
+                    if !hiding {
+                        visible.push(i);
+                    }
+                }
+            }
+        }
+        self.git_visible = visible;
+    }
+
+    /// Toggle the fold of the function whose header is at the given display row
+    /// (terminal cell). No-op if the click isn't on a header.
+    pub fn git_toggle_fold_at(&mut self, row: u16) {
+        if row < self.git_view_top {
+            return;
+        }
+        let pos = self.scroll as usize + (row - self.git_view_top) as usize;
+        let Some(&ri) = self.git_visible.get(pos) else {
+            return;
+        };
+        if matches!(self.git_rows.get(ri), Some(GitRow::Header(_))) {
+            if !self.git_folded.remove(&ri) {
+                self.git_folded.insert(ri);
+            }
+            self.rebuild_git_visible();
+        }
+    }
+
+    /// Kick off the background build of the full-program git diff if it is
+    /// enabled and not already built/building for the current kind. Both disasm
+    /// and decompiled modes stream per function off-thread, so neither waits for
+    /// the full PipelineContext to build.
+    /// Safe to call every tick — it early-returns when there's nothing to do.
+    pub fn request_git_diff(&mut self) {
+        if !self.git_diff || self.git_computing || self.git_built_kind == Some(self.git_kind) {
+            return;
+        }
+        let (Some(file2), Some(format2)) = (self.file2.clone(), self.format2.clone()) else {
+            return;
+        };
+
+        // Build the full A->Z list directly from both files' function maps
+        // (always complete from startup), not from the diff worker's
+        // incrementally-populated list. file 1 functions first, then file-2-only
+        // (added) ones, both sorted by name.
+        let mut names: Vec<String> = self.map1.keys().cloned().collect();
+        names.sort();
+        let mut added: Vec<String> = self
+            .map2
+            .keys()
+            .filter(|n| !self.map1.contains_key(*n))
+            .cloned()
+            .collect();
+        added.sort();
+        names.extend(added);
+
+        let total = names.len();
+        let job = GitDiffJob {
+            names,
+            map1: self.map1.clone(),
+            map2: self.map2.clone(),
+            diff_status: self.diff_status.clone(),
+            file1: Arc::clone(&self.file),
+            file2,
+            format1: Arc::clone(&self.format),
+            format2,
+            kind: self.git_kind,
+            normalize: self.git_normalize,
+        };
+        self.git_rows = Arc::new(Vec::new());
+        self.git_visible.clear();
+        self.git_folded.clear();
+        self.git_progress = (0, total);
+        self.git_rx = Some(gitdiff::spawn(job));
+        self.git_computing = true;
+    }
+
+    /// Scroll to the next git-diff row matching `git_search` (case-insensitive,
+    /// wrapping). No-op if the query is empty or there are no rows.
+    /// Incremental search (used while typing): jump to the first match at or
+    /// after the current position.
+    pub fn git_search_live(&mut self) {
+        self.git_search_jump(true, true);
+    }
+
+    pub fn git_search_next(&mut self) {
+        self.git_search_jump(true, false);
+    }
+
+    pub fn git_search_prev(&mut self) {
+        self.git_search_jump(false, false);
+    }
+
+    /// Find the next/previous visible row matching `git_search` (wrapping),
+    /// update scroll, the total match count and the 1-based current index.
+    /// `inclusive` lets incremental typing match the current row in place.
+    fn git_search_jump(&mut self, forward: bool, inclusive: bool) {
+        let query = self.git_search.to_lowercase();
+        let n = self.git_visible.len();
+        self.git_match_count = if query.is_empty() {
+            0
+        } else {
+            self.git_visible
+                .iter()
+                .filter(|&&ri| gitdiff::row_contains(&self.git_rows[ri], &query))
+                .count()
+        };
+        if self.git_match_count == 0 {
+            self.git_match_index = 0;
+            return;
+        }
+        let cur = (self.scroll as usize).min(n - 1);
+        let first_off = usize::from(!inclusive);
+        for off in first_off..=n {
+            let pos = if forward {
+                (cur + off) % n
+            } else {
+                (cur + n - off) % n
+            };
+            if gitdiff::row_contains(&self.git_rows[self.git_visible[pos]], &query) {
+                self.scroll = pos as u32;
+                self.git_match_index = self.git_visible[..=pos]
+                    .iter()
+                    .filter(|&&ri| gitdiff::row_contains(&self.git_rows[ri], &query))
+                    .count();
+                return;
+            }
         }
     }
 

--- a/crates/hbc-decomp-cli/src/tui/app.rs
+++ b/crates/hbc-decomp-cli/src/tui/app.rs
@@ -1,20 +1,11 @@
-use ratatui::style::{Color, Style};
-use ratatui::text::{Line, Span, Text};
+use ratatui::text::Text;
 use ratatui::widgets::ListState;
-use similar::{DiffTag, TextDiff};
 use std::collections::{HashMap, HashSet};
-use std::sync::{
-    mpsc::{Receiver, TryRecvError},
-    Arc,
-};
+use std::sync::{mpsc::Receiver, Arc};
 use std::time::Instant;
 
-use hbc_decomp::{
-    build_closure_context, decompile_function_v2, decompile_function_v2_with_context, BytecodeFile,
-    BytecodeFormat, ClosureContext, DecompileOptionsV2, PipelineContext,
-};
+use hbc_decomp::{BytecodeFile, BytecodeFormat, ClosureContext, PipelineContext};
 
-use super::formatting::{format_disasm_colored, format_info, highlight_code};
 use super::debug_log;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,13 +89,16 @@ pub struct App {
     pub diff_analyzing: bool,
     pub diff_progress_done: usize,
     pub diff_progress_total: usize,
-    known_names: HashSet<String>,
+    pub(crate) known_names: HashSet<String>,
 
     // Mode used for diff calculation (Assembly or Code)
     pub diff_calc_mode: DiffMode,
 
     // Toggle for content diff highlighting
     pub show_diff_colors: bool,
+
+    // Toggle for the unified (git-style, single column) diff view.
+    pub diff_unified: bool,
 
     // Persistent list state for function list scrolling
     pub list_state: ListState,
@@ -220,6 +214,7 @@ impl App {
                 DiffMode::Assembly
             },
             show_diff_colors: true, // Default to true as user requested colors
+            diff_unified: false,
             list_state: ListState::default().with_selected(Some(0)),
             pipeline_ctx: None,
             pipeline_rx: None,
@@ -337,100 +332,11 @@ impl App {
 
     // strip_offsets removed (moved to module)
 
-    fn add_discovered_name(&mut self, name: String) {
+    pub(crate) fn add_discovered_name(&mut self, name: String) {
         if self.known_names.insert(name.clone()) {
             self.all_function_names.push(name);
             self.all_function_names.sort();
             self.update_search();
-        }
-    }
-
-    pub fn poll_background_tasks(&mut self) {
-        let mut messages = Vec::new();
-        let mut disconnected = false;
-        const MAX_MESSAGES_PER_TICK: usize = 128;
-
-        if let Some(rx) = self.diff_rx.as_ref() {
-            for _ in 0..MAX_MESSAGES_PER_TICK {
-                match rx.try_recv() {
-                    Ok(msg) => messages.push(msg),
-                    Err(TryRecvError::Empty) => break,
-                    Err(TryRecvError::Disconnected) => {
-                        disconnected = true;
-                        break;
-                    }
-                }
-            }
-        }
-
-        for msg in messages {
-            match msg {
-                DiffProgressMsg::Item {
-                    name,
-                    status,
-                    done,
-                    total,
-                } => {
-                    self.diff_status.insert(name.clone(), status);
-                    self.diff_progress_done = done;
-                    self.diff_progress_total = total;
-                    self.add_discovered_name(name);
-                }
-                DiffProgressMsg::Finished { final_status } => {
-                    self.diff_status = final_status;
-                    self.diff_analyzing = false;
-                    self.diff_progress_done = self.diff_status.len();
-                    if self.diff_progress_total == 0 {
-                        self.diff_progress_total = self.diff_status.len();
-                    }
-                    self.all_function_names = self.diff_status.keys().cloned().collect();
-                    self.all_function_names.sort();
-                    self.known_names = self.all_function_names.iter().cloned().collect();
-                    self.update_search();
-                    self.diff_rx = None;
-                }
-            }
-        }
-
-        if disconnected {
-            self.diff_analyzing = false;
-            self.diff_rx = None;
-        }
-
-        // Poll pipeline context (file 1)
-        if let Some(rx) = self.pipeline_rx.as_ref() {
-            match rx.try_recv() {
-                Ok(ctx) => {
-                    debug_log("[TUI] Pipeline context (file 1) received");
-                    self.pipeline_ctx = Some(Arc::new(ctx));
-                    self.pipeline_building = false;
-                    self.pipeline_rx = None;
-                    self.decompile_cache.clear();
-                }
-                Err(TryRecvError::Empty) => {}
-                Err(TryRecvError::Disconnected) => {
-                    self.pipeline_building = false;
-                    self.pipeline_rx = None;
-                }
-            }
-        }
-
-        // Poll pipeline context (file 2)
-        if let Some(rx) = self.pipeline_rx2.as_ref() {
-            match rx.try_recv() {
-                Ok(ctx) => {
-                    debug_log("[TUI] Pipeline context (file 2) received");
-                    self.pipeline_ctx2 = Some(Arc::new(ctx));
-                    self.pipeline_building2 = false;
-                    self.pipeline_rx2 = None;
-                    self.decompile_cache2.clear();
-                }
-                Err(TryRecvError::Empty) => {}
-                Err(TryRecvError::Disconnected) => {
-                    self.pipeline_building2 = false;
-                    self.pipeline_rx2 = None;
-                }
-            }
         }
     }
 
@@ -460,6 +366,20 @@ impl App {
         } else {
             None
         }
+    }
+
+    /// File-2 id for the selected function, resolving renames. Lets us show the
+    /// code of functions that exist only in file 2 ("added"), which have no
+    /// file-1 id.
+    pub fn selected_function_id2(&self) -> Option<u32> {
+        let name = self.selected_function_name()?;
+        if let Some(id) = self.map2.get(name) {
+            return Some(*id);
+        }
+        if let Some(DiffStatus::Renamed(new_name)) = self.diff_status.get(name) {
+            return self.map2.get(new_name).copied();
+        }
+        None
     }
 
     pub fn set_selected(&mut self, index: usize) {
@@ -495,384 +415,6 @@ impl App {
         }
     }
 
-    pub fn content(&mut self) -> (Text<'static>, Option<Text<'static>>) {
-        if self.function_names.is_empty() {
-            if self.diff_analyzing {
-                return (Text::raw("Analyzing functions..."), None);
-            }
-            return (Text::raw("No functions found matching query."), None);
-        }
-
-        match self.view {
-            ViewMode::Info => (Text::raw(self.format_info_wrapper()), None),
-            ViewMode::Disasm => (self.disasm_content(), None),
-            ViewMode::Decompile => (
-                Text::from(highlight_code(&self.decompile_content())),
-                None,
-            ),
-            ViewMode::Diff => {
-                // If showing diff colors, we need to compute the diff and styling manually
-                if self.show_diff_colors && self.file2.is_some() {
-                    let left_str = match self.diff_kind {
-                        ViewMode::Disasm => {
-                            self.get_disasm_string_local(self.selected_function_id())
-                        }
-                        _ => self.decompile_content(), // Returns String
-                    };
-
-                    let right_str = {
-                        let name_opt = self.selected_function_name();
-                        if let Some(name) = name_opt {
-                            let name = name.to_string();
-                            let id2 = if let Some(id) = self.map2.get(&name) {
-                                Some(*id)
-                            } else if let Some(DiffStatus::Renamed(new_name)) =
-                                self.diff_status.get(&name)
-                            {
-                                self.map2.get(new_name).copied()
-                            } else {
-                                None
-                            };
-
-                            if let Some(id2) = id2 {
-                                match self.diff_kind {
-                                    ViewMode::Disasm => self.get_disasm_string_remote(id2),
-                                    _ => self.decompile_content2(id2), // Returns String
-                                }
-                            } else {
-                                String::new() // Function doesn't exist in right
-                            }
-                        } else {
-                            String::new()
-                        }
-                    };
-
-                    if right_str.is_empty() {
-                        let left = match self.diff_kind {
-                            ViewMode::Disasm => self.disasm_content(),
-                            _ => Text::raw(left_str),
-                        };
-                        return (
-                            left,
-                            Some(Text::raw("Function removed or renamed in file 2.")),
-                        );
-                    }
-
-                    // Compute Diff
-                    let diff = TextDiff::from_lines(&left_str, &right_str);
-
-                    // Optimization: Collect lines into Vec for O(1) access
-                    let left_lines_vec: Vec<&str> = left_str.lines().collect();
-                    let right_lines_vec: Vec<&str> = right_str.lines().collect();
-
-                    let mut l_lines = Vec::new();
-                    let mut r_lines = Vec::new();
-
-                    for op in diff.ops() {
-                        match op.tag() {
-                            DiffTag::Delete => {
-                                // Lines only in Left
-                                for i in op.old_range() {
-                                    let content = left_lines_vec.get(i).unwrap_or(&"").to_string();
-                                    l_lines.push(Line::from(Span::styled(
-                                        content,
-                                        Style::default().bg(Color::Red).fg(Color::White),
-                                    )));
-                                    // Padding in Right
-                                    r_lines.push(Line::from(""));
-                                }
-                            }
-                            DiffTag::Insert => {
-                                // Lines only in Right
-                                for i in op.new_range() {
-                                    let content = right_lines_vec.get(i).unwrap_or(&"").to_string();
-                                    r_lines.push(Line::from(Span::styled(
-                                        content,
-                                        Style::default().bg(Color::Green).fg(Color::Black),
-                                    )));
-                                    // Padding in Left
-                                    l_lines.push(Line::from(""));
-                                }
-                            }
-                            DiffTag::Replace => {
-                                // Left has lines, Right has lines.
-                                let old_len = op.old_range().len();
-                                let new_len = op.new_range().len();
-                                let max_len = std::cmp::max(old_len, new_len);
-
-                                for i in 0..max_len {
-                                    if i < old_len {
-                                        let idx = op.old_range().start + i;
-                                        let content =
-                                            left_lines_vec.get(idx).unwrap_or(&"").to_string();
-                                        l_lines.push(Line::from(Span::styled(
-                                            content,
-                                            Style::default().bg(Color::Red).fg(Color::White),
-                                        )));
-                                    } else {
-                                        l_lines.push(Line::from(""));
-                                    }
-
-                                    if i < new_len {
-                                        let idx = op.new_range().start + i;
-                                        let content =
-                                            right_lines_vec.get(idx).unwrap_or(&"").to_string();
-                                        r_lines.push(Line::from(Span::styled(
-                                            content,
-                                            Style::default().bg(Color::Green).fg(Color::Black),
-                                        )));
-                                    } else {
-                                        r_lines.push(Line::from(""));
-                                    }
-                                }
-                            }
-                            DiffTag::Equal => {
-                                for i in op.old_range() {
-                                    let content = left_lines_vec.get(i).unwrap_or(&"").to_string();
-                                    l_lines.push(Line::from(content.clone()));
-                                    r_lines.push(Line::from(content)); // Identical
-                                }
-                            }
-                        }
-                    }
-
-                    (Text::from(l_lines), Some(Text::from(r_lines)))
-                } else {
-                    // Standard non-colored view (or if file2 missing)
-                    let left = match self.diff_kind {
-                        ViewMode::Disasm => self.disasm_content(),
-                        _ => Text::raw(self.decompile_content()),
-                    };
-
-                    let right = if self.file2.is_some() {
-                        let name_opt = self.selected_function_name();
-                        if let Some(name) = name_opt {
-                            let name = name.to_string();
-                            let id2 = if let Some(id) = self.map2.get(&name) {
-                                Some(*id)
-                            } else if let Some(DiffStatus::Renamed(new_name)) =
-                                self.diff_status.get(&name)
-                            {
-                                self.map2.get(new_name).copied()
-                            } else {
-                                None
-                            };
-
-                            if let Some(id2) = id2 {
-                                match self.diff_kind {
-                                    ViewMode::Disasm => Some(self.disasm_content2(id2)),
-                                    _ => Some(Text::raw(self.decompile_content2(id2))),
-                                }
-                            } else {
-                                match self.diff_status.get(&name) {
-                                    Some(DiffStatus::Renamed(new_name)) => {
-                                        Some(Text::raw(format!("Renamed to {new_name}")))
-                                    }
-                                    Some(DiffStatus::Removed) => {
-                                        Some(Text::raw("Function removed in file 2."))
-                                    }
-                                    _ => Some(Text::raw("Function removed or renamed in file 2.")),
-                                }
-                            }
-                        } else {
-                            None
-                        }
-                    } else {
-                        Some(Text::raw("No second file loaded."))
-                    };
-
-                    (left, right)
-                }
-            }
-        }
-    }
-
-    // get_line_from_str removed (optimized out)
-
-    // Helper to get raw string for disasm
-    fn get_disasm_string_local(&self, id_opt: Option<u32>) -> String {
-        if let Some(id) = id_opt {
-            hbc_decomp::disassemble_function(
-                &self.file,
-                &self.format,
-                id,
-                &hbc_decomp::DisasmOptions::default(),
-            )
-            .unwrap_or_default()
-        } else {
-            String::new()
-        }
-    }
-
-    fn get_disasm_string_remote(&self, id: u32) -> String {
-        let (file2, format2) = match (self.file2.as_ref(), self.format2.as_ref()) {
-            (Some(f), Some(fmt)) => (f, fmt),
-            _ => return String::new(),
-        };
-        hbc_decomp::disassemble_function(file2, format2, id, &hbc_decomp::DisasmOptions::default())
-            .unwrap_or_default()
-    }
-
-    // --- Content Generators for File 1 ---
-
-    fn ensure_closure_ctx_local(&mut self) {
-        if self.closure_ctx_attempted {
-            return;
-        }
-        self.closure_ctx_attempted = true;
-        self.closure_ctx = build_closure_context(&self.file, &self.format).ok();
-    }
-
-    fn ensure_closure_ctx_remote(&mut self) {
-        if self.closure_ctx2_attempted {
-            return;
-        }
-        self.closure_ctx2_attempted = true;
-        if let (Some(file2), Some(format2)) = (self.file2.as_ref(), self.format2.as_ref()) {
-            self.closure_ctx2 = build_closure_context(file2, format2).ok();
-        }
-    }
-
-    pub fn disasm_content(&mut self) -> Text<'static> {
-        let function_id = match self.selected_function_id() {
-            Some(id) => id,
-            None => return Text::raw("Function not present in this file (Added in v2)"),
-        };
-
-        if let Some(content) = self.disasm_cache.get(&(function_id as usize)) {
-            return content.clone();
-        }
-
-        let content = match self
-            .file
-            .decode_function_instructions(&self.format, function_id)
-        {
-            Ok(instructions) => format_disasm_colored(&instructions, &self.format, &self.file),
-            Err(e) => Text::raw(format!("Error: {e}")),
-        };
-
-        self.disasm_cache
-            .insert(function_id as usize, content.clone());
-        content
-    }
-
-    pub fn decompile_content(&mut self) -> String {
-        let function_id = match self.selected_function_id() {
-            Some(id) => id,
-            None => return "Function not present in this file (Added in v2)".to_string(),
-        };
-
-        if let Some(content) = self.decompile_cache.get(&(function_id as usize)) {
-            return content.clone();
-        }
-
-        // Use full pipeline context if available (IPA, Metro, naming)
-        let content = if let Some(ctx) = &self.pipeline_ctx {
-            ctx.generate_function_code(&self.file, function_id)
-        } else {
-            // Fallback: basic single-function decompilation while pipeline builds
-            let options = DecompileOptionsV2::optimized();
-            self.ensure_closure_ctx_local();
-
-            if let Some(closure) = self.closure_ctx.as_ref() {
-                decompile_function_v2_with_context(
-                    &self.file,
-                    &self.format,
-                    function_id,
-                    &options,
-                    Some(closure),
-                )
-            } else {
-                decompile_function_v2(&self.file, &self.format, function_id, &options)
-            }
-            .unwrap_or_else(|err| format!("error: {err}"))
-        };
-
-        self.decompile_cache
-            .insert(function_id as usize, content.clone());
-        content
-    }
-
-    // --- Content Generators for File 2 ---
-
-    pub fn disasm_content2(&mut self, function_id: u32) -> Text<'static> {
-        if let Some(content) = self.disasm_cache2.get(&(function_id as usize)) {
-            return content.clone();
-        }
-
-        let (file2, format2) = match (self.file2.as_ref(), self.format2.as_ref()) {
-            (Some(f), Some(fmt)) => (f, fmt),
-            _ => return Text::raw("No second file loaded"),
-        };
-
-        let content = match file2.decode_function_instructions(format2, function_id) {
-            Ok(instructions) => format_disasm_colored(&instructions, format2, file2),
-            Err(e) => Text::raw(format!("Error: {e}")),
-        };
-
-        self.disasm_cache2
-            .insert(function_id as usize, content.clone());
-        content
-    }
-
-    pub fn decompile_content2(&mut self, function_id: u32) -> String {
-        if let Some(content) = self.decompile_cache2.get(&(function_id as usize)) {
-            return content.clone();
-        }
-
-        // Guard: both file2 and format2 must be present for diff mode
-        if self.file2.is_none() || self.format2.is_none() {
-            return "No second file loaded".to_string();
-        }
-
-        let content = if self.pipeline_ctx2.is_some() {
-            // Use full pipeline context if available (IPA, Metro, naming)
-            let file2 = self.file2.as_ref().unwrap();
-            self.pipeline_ctx2
-                .as_ref()
-                .unwrap()
-                .generate_function_code(file2, function_id)
-        } else {
-            // Fallback: basic single-function decompilation while pipeline builds
-            self.ensure_closure_ctx_remote();
-            let file2 = self.file2.as_ref().unwrap();
-            let format2 = self.format2.as_ref().unwrap();
-            let options = DecompileOptionsV2::optimized();
-            if let Some(ctx) = self.closure_ctx2.as_ref() {
-                decompile_function_v2_with_context(file2, format2, function_id, &options, Some(ctx))
-            } else {
-                decompile_function_v2(file2, format2, function_id, &options)
-            }
-            .unwrap_or_else(|err| format!("error: {err}"))
-        };
-
-        self.decompile_cache2
-            .insert(function_id as usize, content.clone());
-        content
-    }
-
-    pub fn format_info_wrapper(&self) -> String {
-        let name_opt = self.selected_function_name();
-        let name = match name_opt {
-            Some(n) => n,
-            None => return "No function selected.".to_string(),
-        };
-        let status = self.diff_status.get(name);
-
-        format_info(
-            &self.file,
-            &self.path,
-            &self.file2,
-            &self.path2,
-            self.selected,
-            &self.function_names,
-            &self.map1,
-            &self.map2,
-            status,
-        )
-    }
-
-    // Fast search: only matches function names (called on every keystroke).
     pub fn update_search(&mut self) {
         if self.search_query.is_empty() {
             self.function_names = self.all_function_names.clone();

--- a/crates/hbc-decomp-cli/src/tui/background.rs
+++ b/crates/hbc-decomp-cli/src/tui/background.rs
@@ -1,0 +1,101 @@
+//! Background-task polling: drains the diff-worker and pipeline-build channels
+//! into `App` state without blocking the UI thread.
+
+use std::sync::mpsc::TryRecvError;
+use std::sync::Arc;
+
+use super::app::App;
+use super::debug_log;
+use super::diff::DiffProgressMsg;
+
+impl App {
+    pub fn poll_background_tasks(&mut self) {
+        let mut messages = Vec::new();
+        let mut disconnected = false;
+        const MAX_MESSAGES_PER_TICK: usize = 128;
+
+        if let Some(rx) = self.diff_rx.as_ref() {
+            for _ in 0..MAX_MESSAGES_PER_TICK {
+                match rx.try_recv() {
+                    Ok(msg) => messages.push(msg),
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => {
+                        disconnected = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        for msg in messages {
+            match msg {
+                DiffProgressMsg::Item {
+                    name,
+                    status,
+                    done,
+                    total,
+                } => {
+                    self.diff_status.insert(name.clone(), status);
+                    self.diff_progress_done = done;
+                    self.diff_progress_total = total;
+                    self.add_discovered_name(name);
+                }
+                DiffProgressMsg::Finished { final_status } => {
+                    self.diff_status = final_status;
+                    self.diff_analyzing = false;
+                    self.diff_progress_done = self.diff_status.len();
+                    if self.diff_progress_total == 0 {
+                        self.diff_progress_total = self.diff_status.len();
+                    }
+                    self.all_function_names = self.diff_status.keys().cloned().collect();
+                    self.all_function_names.sort();
+                    self.known_names = self.all_function_names.iter().cloned().collect();
+                    self.update_search();
+                    self.diff_rx = None;
+                }
+            }
+        }
+
+        if disconnected {
+            self.diff_analyzing = false;
+            self.diff_rx = None;
+        }
+
+        // Poll pipeline context (file 1)
+        if let Some(rx) = self.pipeline_rx.as_ref() {
+            match rx.try_recv() {
+                Ok(ctx) => {
+                    debug_log("[TUI] Pipeline context (file 1) received");
+                    self.pipeline_ctx = Some(Arc::new(ctx));
+                    self.pipeline_building = false;
+                    self.pipeline_rx = None;
+                    self.decompile_cache.clear();
+                }
+                Err(TryRecvError::Empty) => {}
+                Err(TryRecvError::Disconnected) => {
+                    self.pipeline_building = false;
+                    self.pipeline_rx = None;
+                }
+            }
+        }
+
+        // Poll pipeline context (file 2)
+        if let Some(rx) = self.pipeline_rx2.as_ref() {
+            match rx.try_recv() {
+                Ok(ctx) => {
+                    debug_log("[TUI] Pipeline context (file 2) received");
+                    self.pipeline_ctx2 = Some(Arc::new(ctx));
+                    self.pipeline_building2 = false;
+                    self.pipeline_rx2 = None;
+                    self.decompile_cache2.clear();
+                }
+                Err(TryRecvError::Empty) => {}
+                Err(TryRecvError::Disconnected) => {
+                    self.pipeline_building2 = false;
+                    self.pipeline_rx2 = None;
+                }
+            }
+        }
+    }
+
+}

--- a/crates/hbc-decomp-cli/src/tui/background.rs
+++ b/crates/hbc-decomp-cli/src/tui/background.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use super::app::App;
 use super::debug_log;
 use super::diff::DiffProgressMsg;
+use super::gitdiff::GitMsg;
 
 impl App {
     pub fn poll_background_tasks(&mut self) {
@@ -96,6 +97,40 @@ impl App {
                 }
             }
         }
-    }
 
+        // Collect git-diff progress / result, if a worker is running.
+        if self.git_rx.is_some() {
+            for _ in 0..MAX_MESSAGES_PER_TICK {
+                match self.git_rx.as_ref().unwrap().try_recv() {
+                    Ok(GitMsg::Chunk { rows, done, total }) => {
+                        // Append incrementally (O(chunk)); a full rebuild here on
+                        // every chunk was O(total) and made scrolling lag during
+                        // the build. Freshly-streamed rows can't be folded yet,
+                        // so they are all visible.
+                        let store = Arc::make_mut(&mut self.git_rows);
+                        let old_len = store.len();
+                        store.extend(rows);
+                        let new_len = store.len();
+                        self.git_visible.extend(old_len..new_len);
+                        self.git_progress = (done, total);
+                    }
+                    Ok(GitMsg::Done) => {
+                        self.git_built_kind = Some(self.git_kind);
+                        self.git_computing = false;
+                        self.git_rx = None;
+                        break;
+                    }
+                    Err(TryRecvError::Empty) => break,
+                    Err(TryRecvError::Disconnected) => {
+                        self.git_computing = false;
+                        self.git_rx = None;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Kick off (or retry) the git-diff build once its inputs are ready.
+        self.request_git_diff();
+    }
 }

--- a/crates/hbc-decomp-cli/src/tui/content.rs
+++ b/crates/hbc-decomp-cli/src/tui/content.rs
@@ -1,0 +1,491 @@
+//! Content generation for the TUI: per-function disassembly / decompilation for
+//! both files, plus the split/diff rendering driven by `App::content`.
+
+use ratatui::style::{Color, Style};
+use ratatui::text::{Line, Span, Text};
+use similar::{ChangeTag, DiffTag, TextDiff};
+
+use hbc_decomp::{
+    build_closure_context, decompile_function_v2, decompile_function_v2_with_context,
+    DecompileOptionsV2,
+};
+
+use super::app::{App, ViewMode};
+use super::diff::DiffStatus;
+use super::formatting::{format_disasm_colored, format_info, highlight_code};
+
+impl App {
+    pub fn content(&mut self) -> (Text<'static>, Option<Text<'static>>) {
+        if self.function_names.is_empty() {
+            if self.diff_analyzing {
+                return (Text::raw("Analyzing functions..."), None);
+            }
+            return (Text::raw("No functions found matching query."), None);
+        }
+
+        // A function that exists only in file 2 ("added") has no file-1 id, so
+        // the normal single-pane views would just say "not present". Fall back
+        // to its file-2 code so it is actually viewable. (The split diff view
+        // below keeps the left pane on file 1 on purpose.)
+        let only_in_file2 =
+            self.selected_function_id().is_none() && self.selected_function_id2().is_some();
+
+        match self.view {
+            ViewMode::Info => (Text::raw(self.format_info_wrapper()), None),
+            ViewMode::Disasm => {
+                if only_in_file2 {
+                    let id2 = self.selected_function_id2().unwrap();
+                    return (self.disasm_content2(id2), None);
+                }
+                (self.disasm_content(), None)
+            }
+            ViewMode::Decompile => {
+                if only_in_file2 {
+                    let id2 = self.selected_function_id2().unwrap();
+                    return (Text::from(highlight_code(&self.decompile_content2(id2))), None);
+                }
+                (Text::from(highlight_code(&self.decompile_content())), None)
+            }
+            ViewMode::Diff => {
+                // Unified (git-style) single-column view, if toggled with `u`.
+                if self.diff_unified && self.file2.is_some() {
+                    return (self.unified_diff_text(), None);
+                }
+                // If showing diff colors, we need to compute the diff and styling manually
+                if self.show_diff_colors && self.file2.is_some() {
+                    let left_str = match self.diff_kind {
+                        ViewMode::Disasm => {
+                            self.get_disasm_string_local(self.selected_function_id())
+                        }
+                        _ => self.decompile_content(), // Returns String
+                    };
+
+                    let right_str = {
+                        let name_opt = self.selected_function_name();
+                        if let Some(name) = name_opt {
+                            let name = name.to_string();
+                            let id2 = if let Some(id) = self.map2.get(&name) {
+                                Some(*id)
+                            } else if let Some(DiffStatus::Renamed(new_name)) =
+                                self.diff_status.get(&name)
+                            {
+                                self.map2.get(new_name).copied()
+                            } else {
+                                None
+                            };
+
+                            if let Some(id2) = id2 {
+                                match self.diff_kind {
+                                    ViewMode::Disasm => self.get_disasm_string_remote(id2),
+                                    _ => self.decompile_content2(id2), // Returns String
+                                }
+                            } else {
+                                String::new() // Function doesn't exist in right
+                            }
+                        } else {
+                            String::new()
+                        }
+                    };
+
+                    if right_str.is_empty() {
+                        let left = match self.diff_kind {
+                            ViewMode::Disasm => self.disasm_content(),
+                            _ => Text::raw(left_str),
+                        };
+                        return (
+                            left,
+                            Some(Text::raw("Function removed or renamed in file 2.")),
+                        );
+                    }
+
+                    // Compute Diff
+                    let diff = TextDiff::from_lines(&left_str, &right_str);
+
+                    // Optimization: Collect lines into Vec for O(1) access
+                    let left_lines_vec: Vec<&str> = left_str.lines().collect();
+                    let right_lines_vec: Vec<&str> = right_str.lines().collect();
+
+                    let mut l_lines = Vec::new();
+                    let mut r_lines = Vec::new();
+
+                    for op in diff.ops() {
+                        match op.tag() {
+                            DiffTag::Delete => {
+                                // Lines only in Left
+                                for i in op.old_range() {
+                                    let content = left_lines_vec.get(i).unwrap_or(&"").to_string();
+                                    l_lines.push(Line::from(Span::styled(
+                                        content,
+                                        Style::default().bg(Color::Red).fg(Color::White),
+                                    )));
+                                    // Padding in Right
+                                    r_lines.push(Line::from(""));
+                                }
+                            }
+                            DiffTag::Insert => {
+                                // Lines only in Right
+                                for i in op.new_range() {
+                                    let content = right_lines_vec.get(i).unwrap_or(&"").to_string();
+                                    r_lines.push(Line::from(Span::styled(
+                                        content,
+                                        Style::default().bg(Color::Green).fg(Color::Black),
+                                    )));
+                                    // Padding in Left
+                                    l_lines.push(Line::from(""));
+                                }
+                            }
+                            DiffTag::Replace => {
+                                // Left has lines, Right has lines.
+                                let old_len = op.old_range().len();
+                                let new_len = op.new_range().len();
+                                let max_len = std::cmp::max(old_len, new_len);
+
+                                for i in 0..max_len {
+                                    if i < old_len {
+                                        let idx = op.old_range().start + i;
+                                        let content =
+                                            left_lines_vec.get(idx).unwrap_or(&"").to_string();
+                                        l_lines.push(Line::from(Span::styled(
+                                            content,
+                                            Style::default().bg(Color::Red).fg(Color::White),
+                                        )));
+                                    } else {
+                                        l_lines.push(Line::from(""));
+                                    }
+
+                                    if i < new_len {
+                                        let idx = op.new_range().start + i;
+                                        let content =
+                                            right_lines_vec.get(idx).unwrap_or(&"").to_string();
+                                        r_lines.push(Line::from(Span::styled(
+                                            content,
+                                            Style::default().bg(Color::Green).fg(Color::Black),
+                                        )));
+                                    } else {
+                                        r_lines.push(Line::from(""));
+                                    }
+                                }
+                            }
+                            DiffTag::Equal => {
+                                for i in op.old_range() {
+                                    let content = left_lines_vec.get(i).unwrap_or(&"").to_string();
+                                    l_lines.push(Line::from(content.clone()));
+                                    r_lines.push(Line::from(content)); // Identical
+                                }
+                            }
+                        }
+                    }
+
+                    (Text::from(l_lines), Some(Text::from(r_lines)))
+                } else {
+                    // Standard non-colored view (or if file2 missing)
+                    let left = match self.diff_kind {
+                        ViewMode::Disasm => self.disasm_content(),
+                        _ => Text::raw(self.decompile_content()),
+                    };
+
+                    let right = if self.file2.is_some() {
+                        let name_opt = self.selected_function_name();
+                        if let Some(name) = name_opt {
+                            let name = name.to_string();
+                            let id2 = if let Some(id) = self.map2.get(&name) {
+                                Some(*id)
+                            } else if let Some(DiffStatus::Renamed(new_name)) =
+                                self.diff_status.get(&name)
+                            {
+                                self.map2.get(new_name).copied()
+                            } else {
+                                None
+                            };
+
+                            if let Some(id2) = id2 {
+                                match self.diff_kind {
+                                    ViewMode::Disasm => Some(self.disasm_content2(id2)),
+                                    _ => Some(Text::raw(self.decompile_content2(id2))),
+                                }
+                            } else {
+                                match self.diff_status.get(&name) {
+                                    Some(DiffStatus::Renamed(new_name)) => {
+                                        Some(Text::raw(format!("Renamed to {new_name}")))
+                                    }
+                                    Some(DiffStatus::Removed) => {
+                                        Some(Text::raw("Function removed in file 2."))
+                                    }
+                                    _ => Some(Text::raw("Function removed or renamed in file 2.")),
+                                }
+                            }
+                        } else {
+                            None
+                        }
+                    } else {
+                        Some(Text::raw("No second file loaded."))
+                    };
+
+                    (left, right)
+                }
+            }
+        }
+    }
+
+    // get_line_from_str removed (optimized out)
+
+    // Helper to get raw string for disasm
+    fn get_disasm_string_local(&self, id_opt: Option<u32>) -> String {
+        if let Some(id) = id_opt {
+            hbc_decomp::disassemble_function(
+                &self.file,
+                &self.format,
+                id,
+                &hbc_decomp::DisasmOptions::default(),
+            )
+            .unwrap_or_default()
+        } else {
+            String::new()
+        }
+    }
+
+    fn get_disasm_string_remote(&self, id: u32) -> String {
+        let (file2, format2) = match (self.file2.as_ref(), self.format2.as_ref()) {
+            (Some(f), Some(fmt)) => (f, fmt),
+            _ => return String::new(),
+        };
+        hbc_decomp::disassemble_function(file2, format2, id, &hbc_decomp::DisasmOptions::default())
+            .unwrap_or_default()
+    }
+
+    // --- Content Generators for File 1 ---
+
+    fn ensure_closure_ctx_local(&mut self) {
+        if self.closure_ctx_attempted {
+            return;
+        }
+        self.closure_ctx_attempted = true;
+        self.closure_ctx = build_closure_context(&self.file, &self.format).ok();
+    }
+
+    fn ensure_closure_ctx_remote(&mut self) {
+        if self.closure_ctx2_attempted {
+            return;
+        }
+        self.closure_ctx2_attempted = true;
+        if let (Some(file2), Some(format2)) = (self.file2.as_ref(), self.format2.as_ref()) {
+            self.closure_ctx2 = build_closure_context(file2, format2).ok();
+        }
+    }
+
+    pub fn disasm_content(&mut self) -> Text<'static> {
+        let function_id = match self.selected_function_id() {
+            Some(id) => id,
+            None => return Text::raw("Function not present in this file (Added in v2)"),
+        };
+
+        if let Some(content) = self.disasm_cache.get(&(function_id as usize)) {
+            return content.clone();
+        }
+
+        let content = match self
+            .file
+            .decode_function_instructions(&self.format, function_id)
+        {
+            Ok(instructions) => format_disasm_colored(&instructions, &self.format, &self.file),
+            Err(e) => Text::raw(format!("Error: {e}")),
+        };
+
+        self.disasm_cache
+            .insert(function_id as usize, content.clone());
+        content
+    }
+
+    pub fn decompile_content(&mut self) -> String {
+        let function_id = match self.selected_function_id() {
+            Some(id) => id,
+            None => return "Function not present in this file (Added in v2)".to_string(),
+        };
+
+        if let Some(content) = self.decompile_cache.get(&(function_id as usize)) {
+            return content.clone();
+        }
+
+        // Use full pipeline context if available (IPA, Metro, naming)
+        let content = if let Some(ctx) = &self.pipeline_ctx {
+            ctx.generate_function_code(&self.file, function_id)
+        } else {
+            // Fallback: basic single-function decompilation while pipeline builds
+            let options = DecompileOptionsV2::optimized();
+            self.ensure_closure_ctx_local();
+
+            if let Some(closure) = self.closure_ctx.as_ref() {
+                decompile_function_v2_with_context(
+                    &self.file,
+                    &self.format,
+                    function_id,
+                    &options,
+                    Some(closure),
+                )
+            } else {
+                decompile_function_v2(&self.file, &self.format, function_id, &options)
+            }
+            .unwrap_or_else(|err| format!("error: {err}"))
+        };
+
+        self.decompile_cache
+            .insert(function_id as usize, content.clone());
+        content
+    }
+
+    // --- Content Generators for File 2 ---
+
+    pub fn disasm_content2(&mut self, function_id: u32) -> Text<'static> {
+        if let Some(content) = self.disasm_cache2.get(&(function_id as usize)) {
+            return content.clone();
+        }
+
+        let (file2, format2) = match (self.file2.as_ref(), self.format2.as_ref()) {
+            (Some(f), Some(fmt)) => (f, fmt),
+            _ => return Text::raw("No second file loaded"),
+        };
+
+        let content = match file2.decode_function_instructions(format2, function_id) {
+            Ok(instructions) => format_disasm_colored(&instructions, format2, file2),
+            Err(e) => Text::raw(format!("Error: {e}")),
+        };
+
+        self.disasm_cache2
+            .insert(function_id as usize, content.clone());
+        content
+    }
+
+    pub fn decompile_content2(&mut self, function_id: u32) -> String {
+        if let Some(content) = self.decompile_cache2.get(&(function_id as usize)) {
+            return content.clone();
+        }
+
+        // Guard: both file2 and format2 must be present for diff mode
+        if self.file2.is_none() || self.format2.is_none() {
+            return "No second file loaded".to_string();
+        }
+
+        let content = if self.pipeline_ctx2.is_some() {
+            // Use full pipeline context if available (IPA, Metro, naming)
+            let file2 = self.file2.as_ref().unwrap();
+            self.pipeline_ctx2
+                .as_ref()
+                .unwrap()
+                .generate_function_code(file2, function_id)
+        } else {
+            // Fallback: basic single-function decompilation while pipeline builds
+            self.ensure_closure_ctx_remote();
+            let file2 = self.file2.as_ref().unwrap();
+            let format2 = self.format2.as_ref().unwrap();
+            let options = DecompileOptionsV2::optimized();
+            if let Some(ctx) = self.closure_ctx2.as_ref() {
+                decompile_function_v2_with_context(file2, format2, function_id, &options, Some(ctx))
+            } else {
+                decompile_function_v2(file2, format2, function_id, &options)
+            }
+            .unwrap_or_else(|err| format!("error: {err}"))
+        };
+
+        self.decompile_cache2
+            .insert(function_id as usize, content.clone());
+        content
+    }
+
+    pub fn format_info_wrapper(&self) -> String {
+        let name_opt = self.selected_function_name();
+        let name = match name_opt {
+            Some(n) => n,
+            None => return "No function selected.".to_string(),
+        };
+        let status = self.diff_status.get(name);
+
+        format_info(
+            &self.file,
+            &self.path,
+            &self.file2,
+            &self.path2,
+            self.selected,
+            &self.function_names,
+            &self.map1,
+            &self.map2,
+            status,
+        )
+    }
+
+    /// Left (file 1) and right (file 2) source for the selected function's
+    /// diff. A side is empty when the function exists only in the other file
+    /// (added / removed).
+    fn diff_left_right(&mut self) -> (String, String) {
+        let left = if self.selected_function_id().is_some() {
+            match self.diff_kind {
+                ViewMode::Disasm => self.get_disasm_string_local(self.selected_function_id()),
+                _ => self.decompile_content(),
+            }
+        } else {
+            String::new()
+        };
+        let right = if let Some(id2) = self.selected_function_id2() {
+            match self.diff_kind {
+                ViewMode::Disasm => self.get_disasm_string_remote(id2),
+                _ => self.decompile_content2(id2),
+            }
+        } else {
+            String::new()
+        };
+        (left, right)
+    }
+
+    /// Git-style unified diff of the selected function: a single column showing
+    /// the full before/after with `-`/`+` markers and old/new line numbers.
+    fn unified_diff_text(&mut self) -> Text<'static> {
+        let (left, right) = self.diff_left_right();
+        let kind = match self.diff_kind {
+            ViewMode::Disasm => "disassembly",
+            _ => "decompiled code",
+        };
+        let name = self.selected_function_name().unwrap_or("?").to_string();
+
+        let mut lines: Vec<Line<'static>> = vec![
+            Line::from(Span::styled(
+                format!("--- file 1: {name} ({kind})"),
+                Style::default().fg(Color::Red),
+            )),
+            Line::from(Span::styled(
+                format!("+++ file 2: {name} ({kind})"),
+                Style::default().fg(Color::Green),
+            )),
+            Line::from(Span::styled(
+                "  old   new",
+                Style::default().fg(Color::DarkGray),
+            )),
+        ];
+
+        let diff = TextDiff::from_lines(&left, &right);
+        for change in diff.iter_all_changes() {
+            let old_n = change
+                .old_index()
+                .map(|i| format!("{:>5}", i + 1))
+                .unwrap_or_else(|| "     ".to_string());
+            let new_n = change
+                .new_index()
+                .map(|i| format!("{:>5}", i + 1))
+                .unwrap_or_else(|| "     ".to_string());
+            let (sign, color) = match change.tag() {
+                ChangeTag::Delete => ('-', Some(Color::Red)),
+                ChangeTag::Insert => ('+', Some(Color::Green)),
+                ChangeTag::Equal => (' ', None),
+            };
+            let text = change.value().trim_end_matches('\n').to_string();
+            let content_style = color.map_or_else(Style::default, |c| Style::default().fg(c));
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("{old_n} {new_n} {sign} "),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(text, content_style),
+            ]));
+        }
+
+        Text::from(lines)
+    }
+}

--- a/crates/hbc-decomp-cli/src/tui/content.rs
+++ b/crates/hbc-decomp-cli/src/tui/content.rs
@@ -3,16 +3,14 @@
 
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span, Text};
-use similar::{ChangeTag, DiffTag, TextDiff};
+use similar::{DiffTag, TextDiff};
 
-use hbc_decomp::{
-    build_closure_context, decompile_function_v2, decompile_function_v2_with_context,
-    DecompileOptionsV2,
-};
+use hbc_decomp::DecompileOptionsV2;
 
 use super::app::{App, ViewMode};
 use super::diff::DiffStatus;
 use super::formatting::{format_disasm_colored, format_info, highlight_code};
+use super::{decompile_or_log, disasm_or_log};
 
 impl App {
     pub fn content(&mut self) -> (Text<'static>, Option<Text<'static>>) {
@@ -47,10 +45,6 @@ impl App {
                 (Text::from(highlight_code(&self.decompile_content())), None)
             }
             ViewMode::Diff => {
-                // Unified (git-style) single-column view, if toggled with `u`.
-                if self.diff_unified && self.file2.is_some() {
-                    return (self.unified_diff_text(), None);
-                }
                 // If showing diff colors, we need to compute the diff and styling manually
                 if self.show_diff_colors && self.file2.is_some() {
                     let left_str = match self.diff_kind {
@@ -231,47 +225,20 @@ impl App {
 
     // Helper to get raw string for disasm
     fn get_disasm_string_local(&self, id_opt: Option<u32>) -> String {
-        if let Some(id) = id_opt {
-            hbc_decomp::disassemble_function(
-                &self.file,
-                &self.format,
-                id,
-                &hbc_decomp::DisasmOptions::default(),
-            )
-            .unwrap_or_default()
-        } else {
-            String::new()
+        match id_opt {
+            Some(id) => disasm_or_log(&self.file, &self.format, id),
+            None => String::new(),
         }
     }
 
     fn get_disasm_string_remote(&self, id: u32) -> String {
-        let (file2, format2) = match (self.file2.as_ref(), self.format2.as_ref()) {
-            (Some(f), Some(fmt)) => (f, fmt),
-            _ => return String::new(),
-        };
-        hbc_decomp::disassemble_function(file2, format2, id, &hbc_decomp::DisasmOptions::default())
-            .unwrap_or_default()
+        match (self.file2.as_ref(), self.format2.as_ref()) {
+            (Some(file2), Some(format2)) => disasm_or_log(file2, format2, id),
+            _ => String::new(),
+        }
     }
 
     // --- Content Generators for File 1 ---
-
-    fn ensure_closure_ctx_local(&mut self) {
-        if self.closure_ctx_attempted {
-            return;
-        }
-        self.closure_ctx_attempted = true;
-        self.closure_ctx = build_closure_context(&self.file, &self.format).ok();
-    }
-
-    fn ensure_closure_ctx_remote(&mut self) {
-        if self.closure_ctx2_attempted {
-            return;
-        }
-        self.closure_ctx2_attempted = true;
-        if let (Some(file2), Some(format2)) = (self.file2.as_ref(), self.format2.as_ref()) {
-            self.closure_ctx2 = build_closure_context(file2, format2).ok();
-        }
-    }
 
     pub fn disasm_content(&mut self) -> Text<'static> {
         let function_id = match self.selected_function_id() {
@@ -306,26 +273,22 @@ impl App {
             return content.clone();
         }
 
-        // Use full pipeline context if available (IPA, Metro, naming)
+        // Decompiled output was requested: make sure the (lazy) pipeline is
+        // building so quality upgrades once it's ready.
+        if self.pipeline_ctx.is_none() {
+            self.ensure_pipeline_building();
+        }
+
+        // Use full pipeline context if available (IPA, Metro, naming). Otherwise
+        // fall back to a fast single-function decompile — NEVER build a
+        // whole-file closure context here: that ran on the UI thread inside
+        // terminal.draw() and froze the TUI for seconds on large bundles. The
+        // background pipeline upgrades quality once it's ready.
         let content = if let Some(ctx) = &self.pipeline_ctx {
             ctx.generate_function_code(&self.file, function_id)
         } else {
-            // Fallback: basic single-function decompilation while pipeline builds
             let options = DecompileOptionsV2::optimized();
-            self.ensure_closure_ctx_local();
-
-            if let Some(closure) = self.closure_ctx.as_ref() {
-                decompile_function_v2_with_context(
-                    &self.file,
-                    &self.format,
-                    function_id,
-                    &options,
-                    Some(closure),
-                )
-            } else {
-                decompile_function_v2(&self.file, &self.format, function_id, &options)
-            }
-            .unwrap_or_else(|err| format!("error: {err}"))
+            decompile_or_log(&self.file, &self.format, function_id, &options)
         };
 
         self.decompile_cache
@@ -373,17 +336,12 @@ impl App {
                 .unwrap()
                 .generate_function_code(file2, function_id)
         } else {
-            // Fallback: basic single-function decompilation while pipeline builds
-            self.ensure_closure_ctx_remote();
+            // Fast fallback while the pipeline builds — no whole-file work on
+            // the UI thread (see decompile_content for why).
             let file2 = self.file2.as_ref().unwrap();
             let format2 = self.format2.as_ref().unwrap();
             let options = DecompileOptionsV2::optimized();
-            if let Some(ctx) = self.closure_ctx2.as_ref() {
-                decompile_function_v2_with_context(file2, format2, function_id, &options, Some(ctx))
-            } else {
-                decompile_function_v2(file2, format2, function_id, &options)
-            }
-            .unwrap_or_else(|err| format!("error: {err}"))
+            decompile_or_log(file2, format2, function_id, &options)
         };
 
         self.decompile_cache2
@@ -412,80 +370,4 @@ impl App {
         )
     }
 
-    /// Left (file 1) and right (file 2) source for the selected function's
-    /// diff. A side is empty when the function exists only in the other file
-    /// (added / removed).
-    fn diff_left_right(&mut self) -> (String, String) {
-        let left = if self.selected_function_id().is_some() {
-            match self.diff_kind {
-                ViewMode::Disasm => self.get_disasm_string_local(self.selected_function_id()),
-                _ => self.decompile_content(),
-            }
-        } else {
-            String::new()
-        };
-        let right = if let Some(id2) = self.selected_function_id2() {
-            match self.diff_kind {
-                ViewMode::Disasm => self.get_disasm_string_remote(id2),
-                _ => self.decompile_content2(id2),
-            }
-        } else {
-            String::new()
-        };
-        (left, right)
-    }
-
-    /// Git-style unified diff of the selected function: a single column showing
-    /// the full before/after with `-`/`+` markers and old/new line numbers.
-    fn unified_diff_text(&mut self) -> Text<'static> {
-        let (left, right) = self.diff_left_right();
-        let kind = match self.diff_kind {
-            ViewMode::Disasm => "disassembly",
-            _ => "decompiled code",
-        };
-        let name = self.selected_function_name().unwrap_or("?").to_string();
-
-        let mut lines: Vec<Line<'static>> = vec![
-            Line::from(Span::styled(
-                format!("--- file 1: {name} ({kind})"),
-                Style::default().fg(Color::Red),
-            )),
-            Line::from(Span::styled(
-                format!("+++ file 2: {name} ({kind})"),
-                Style::default().fg(Color::Green),
-            )),
-            Line::from(Span::styled(
-                "  old   new",
-                Style::default().fg(Color::DarkGray),
-            )),
-        ];
-
-        let diff = TextDiff::from_lines(&left, &right);
-        for change in diff.iter_all_changes() {
-            let old_n = change
-                .old_index()
-                .map(|i| format!("{:>5}", i + 1))
-                .unwrap_or_else(|| "     ".to_string());
-            let new_n = change
-                .new_index()
-                .map(|i| format!("{:>5}", i + 1))
-                .unwrap_or_else(|| "     ".to_string());
-            let (sign, color) = match change.tag() {
-                ChangeTag::Delete => ('-', Some(Color::Red)),
-                ChangeTag::Insert => ('+', Some(Color::Green)),
-                ChangeTag::Equal => (' ', None),
-            };
-            let text = change.value().trim_end_matches('\n').to_string();
-            let content_style = color.map_or_else(Style::default, |c| Style::default().fg(c));
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("{old_n} {new_n} {sign} "),
-                    Style::default().fg(Color::DarkGray),
-                ),
-                Span::styled(text, content_style),
-            ]));
-        }
-
-        Text::from(lines)
-    }
 }

--- a/crates/hbc-decomp-cli/src/tui/diff.rs
+++ b/crates/hbc-decomp-cli/src/tui/diff.rs
@@ -1,10 +1,10 @@
-use hbc_decomp::{decompile_function_v2, BytecodeFile, BytecodeFormat, DecompileOptionsV2};
+use hbc_decomp::{BytecodeFile, BytecodeFormat, DecompileOptionsV2};
 use std::collections::HashMap;
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Instant;
 
-use super::debug_log;
+use super::{debug_log, decompile_or_log, disasm_or_log};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiffMode {
@@ -66,20 +66,8 @@ pub fn compare_functions(
     match mode {
         DiffMode::Assembly => {
             // Deep comparison via disassembly
-            let dis1 = hbc_decomp::disassemble_function(
-                file1,
-                format1,
-                id1,
-                &hbc_decomp::DisasmOptions::default(),
-            )
-            .unwrap_or_default();
-            let dis2 = hbc_decomp::disassemble_function(
-                file2,
-                format2,
-                id2,
-                &hbc_decomp::DisasmOptions::default(),
-            )
-            .unwrap_or_default();
+            let dis1 = disasm_or_log(file1, format1, id1);
+            let dis2 = disasm_or_log(file2, format2, id2);
 
             if strip_offsets(&dis1) == strip_offsets(&dis2) {
                 DiffStatus::Identical
@@ -89,8 +77,8 @@ pub fn compare_functions(
         }
         DiffMode::Code => {
             let options = DecompileOptionsV2::optimized();
-            let code1 = decompile_function_v2(file1, format1, id1, &options).unwrap_or_default();
-            let code2 = decompile_function_v2(file2, format2, id2, &options).unwrap_or_default();
+            let code1 = decompile_or_log(file1, format1, id1, &options);
+            let code2 = decompile_or_log(file2, format2, id2, &options);
 
             if code1 == code2 {
                 DiffStatus::Identical
@@ -147,19 +135,10 @@ fn apply_rename_detection(
         for name in &added_names {
             let id = ctx2.map[name];
             let content = match mode {
-                DiffMode::Assembly => {
-                    let dis = hbc_decomp::disassemble_function(
-                        ctx2.file,
-                        ctx2.format,
-                        id,
-                        &hbc_decomp::DisasmOptions::default(),
-                    )
-                    .unwrap_or_default();
-                    strip_offsets(&dis)
-                }
+                DiffMode::Assembly => strip_offsets(&disasm_or_log(ctx2.file, ctx2.format, id)),
                 DiffMode::Code => {
                     let options = DecompileOptionsV2::optimized();
-                    decompile_function_v2(ctx2.file, ctx2.format, id, &options).unwrap_or_default()
+                    decompile_or_log(ctx2.file, ctx2.format, id, &options)
                 }
             };
             if !content.is_empty() {
@@ -171,19 +150,10 @@ fn apply_rename_detection(
         for name in removed_names {
             let id = ctx1.map[&name];
             let content = match mode {
-                DiffMode::Assembly => {
-                    let dis = hbc_decomp::disassemble_function(
-                        ctx1.file,
-                        ctx1.format,
-                        id,
-                        &hbc_decomp::DisasmOptions::default(),
-                    )
-                    .unwrap_or_default();
-                    strip_offsets(&dis)
-                }
+                DiffMode::Assembly => strip_offsets(&disasm_or_log(ctx1.file, ctx1.format, id)),
                 DiffMode::Code => {
                     let options = DecompileOptionsV2::optimized();
-                    decompile_function_v2(ctx1.file, ctx1.format, id, &options).unwrap_or_default()
+                    decompile_or_log(ctx1.file, ctx1.format, id, &options)
                 }
             };
 

--- a/crates/hbc-decomp-cli/src/tui/events.rs
+++ b/crates/hbc-decomp-cli/src/tui/events.rs
@@ -1,7 +1,10 @@
 use std::io::{self, Stdout};
 use std::time::Duration;
 
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::event::{
+    self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent,
+    MouseEventKind,
+};
 use ratatui::Terminal;
 
 use super::app::{App, ViewMode};
@@ -13,20 +16,39 @@ pub fn run_loop(
 ) -> io::Result<()> {
     loop {
         terminal.draw(|frame| draw_ui(frame, app))?;
+        app.tick = app.tick.wrapping_add(1);
 
-        if event::poll(Duration::from_millis(250))? {
-            match event::read()? {
-                // Only react to key *presses*: with the crossterm 0.29 enhanced
-                // protocol, repeats/releases also arrive and would double every
-                // action (navigation, toggles).
-                Event::Key(key) if key.kind == KeyEventKind::Press => {
-                    if handle_key(app, key) {
-                        break;
+        // Spin faster while loading (animated spinner), idle slower.
+        let loading = app.git_computing || app.pipeline_building || app.pipeline_building2;
+        let timeout = Duration::from_millis(if loading { 80 } else { 200 });
+
+        if event::poll(timeout)? {
+            // Drain ALL pending events before redrawing once. Trackpad/wheel
+            // scrolling emits many events per gesture; handling them one-redraw-
+            // each made scrolling lag badly.
+            let mut quit = false;
+            loop {
+                match event::read()? {
+                    // Only react to key *presses*: the crossterm 0.29 enhanced
+                    // protocol also sends repeats/releases, which would double
+                    // every action.
+                    Event::Key(key) if key.kind == KeyEventKind::Press => {
+                        if handle_key(app, key) {
+                            quit = true;
+                            break;
+                        }
                     }
+                    Event::Mouse(me) => handle_mouse(app, me),
+                    // Force a full repaint on resize so no stale cells linger.
+                    Event::Resize(_, _) => terminal.clear()?,
+                    _ => {}
                 }
-                // Force a full repaint on resize so no stale cells linger.
-                Event::Resize(_, _) => terminal.clear()?,
-                _ => {}
+                if !event::poll(Duration::from_millis(0))? {
+                    break;
+                }
+            }
+            if quit {
+                break;
             }
         }
 
@@ -59,6 +81,11 @@ fn handle_key(app: &mut App, key: KeyEvent) -> bool {
             _ => {}
         }
         return false;
+    }
+
+    // Full-program git diff is a separate full-screen mode with its own keys.
+    if app.git_diff {
+        return handle_git_key(app, key);
     }
 
     let has_diff = app.file2.is_some();
@@ -111,12 +138,13 @@ fn handle_key(app: &mut App, key: KeyEvent) -> bool {
             ViewMode::Decompile => app.set_view(ViewMode::Disasm),
             _ => app.set_view(ViewMode::Decompile),
         },
-        // `u` switches the diff view between split (side-by-side) and unified
-        // (git-style single column).
+        // `u` enters the full-program git diff (whole code, base vs modified,
+        // side by side). Only meaningful when a second file is loaded.
         KeyCode::Char('u') => {
-            if app.view == ViewMode::Diff {
-                app.diff_unified = !app.diff_unified;
+            if app.file2.is_some() {
+                app.git_diff = true;
                 app.scroll = 0;
+                app.request_git_diff();
             }
         }
         _ => {}
@@ -138,5 +166,87 @@ fn handle_key(app: &mut App, key: KeyEvent) -> bool {
         }
     }
 
+    false
+}
+
+/// Mouse: wheel scrolls the active view, left click selects a function in the
+/// list (normal mode).
+fn handle_mouse(app: &mut App, me: MouseEvent) {
+    match me.kind {
+        MouseEventKind::ScrollDown => app.scroll = app.scroll.saturating_add(3),
+        MouseEventKind::ScrollUp => app.scroll = app.scroll.saturating_sub(3),
+        MouseEventKind::Down(MouseButton::Left) => {
+            if app.git_diff {
+                app.git_toggle_fold_at(me.row); // click a ▼/▶ header to fold
+            } else {
+                app.select_at_row(me.column, me.row);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Keys for the full-program git diff mode (no function list; both columns are
+/// scrolled together).
+fn handle_git_key(app: &mut App, key: KeyEvent) -> bool {
+    // Search input mode.
+    if app.git_searching {
+        match key.code {
+            KeyCode::Esc => app.git_searching = false,
+            // Navigate matches while the popup stays open. Use Enter/arrows so
+            // letter keys (n/N) keep going into the query text.
+            KeyCode::Enter | KeyCode::Down => app.git_search_next(),
+            KeyCode::Up => app.git_search_prev(),
+            KeyCode::Backspace => {
+                app.git_search.pop();
+                app.git_search_live();
+            }
+            KeyCode::Char(c) => {
+                app.git_search.push(c);
+                app.git_search_live(); // incremental: jump as you type
+            }
+            _ => {}
+        }
+        return false;
+    }
+
+    match key.code {
+        KeyCode::Char('q') => return true,
+        // Search within the diff. `/` opens input; n/N or Enter cycle matches.
+        KeyCode::Char('/') => app.git_searching = true,
+        KeyCode::Char('n') | KeyCode::Enter => app.git_search_next(),
+        KeyCode::Char('N') => app.git_search_prev(),
+        // Leave the git diff and go back to the normal browser.
+        KeyCode::Char('u') | KeyCode::Esc => {
+            app.git_diff = false;
+            app.scroll = 0;
+        }
+        // Toggle decompiled vs disassembly; rebuild the diff for the new kind.
+        KeyCode::Char('v') => {
+            app.git_kind = match app.git_kind {
+                ViewMode::Disasm => ViewMode::Decompile,
+                _ => ViewMode::Disasm,
+            };
+            app.invalidate_git_diff();
+            app.request_git_diff();
+            app.scroll = 0;
+        }
+        // Toggle syntax coloring (vs. plain red/green diff tint).
+        KeyCode::Char('c') => app.git_syntax = !app.git_syntax,
+        // Toggle ignoring volatile Metro ids (module_955 vs module_769).
+        KeyCode::Char('i') => {
+            app.git_normalize = !app.git_normalize;
+            app.invalidate_git_diff();
+            app.request_git_diff();
+            app.scroll = 0;
+        }
+        KeyCode::Down | KeyCode::Char('j') => app.scroll = app.scroll.saturating_add(1),
+        KeyCode::Up | KeyCode::Char('k') => app.scroll = app.scroll.saturating_sub(1),
+        KeyCode::PageDown => app.scroll = app.scroll.saturating_add(20),
+        KeyCode::PageUp => app.scroll = app.scroll.saturating_sub(20),
+        KeyCode::Home => app.scroll = 0,
+        KeyCode::End => app.scroll = u32::MAX, // clamped during rendering
+        _ => {}
+    }
     false
 }

--- a/crates/hbc-decomp-cli/src/tui/events.rs
+++ b/crates/hbc-decomp-cli/src/tui/events.rs
@@ -1,7 +1,7 @@
 use std::io::{self, Stdout};
 use std::time::Duration;
 
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use ratatui::Terminal;
 
 use super::app::{App, ViewMode};
@@ -15,10 +15,18 @@ pub fn run_loop(
         terminal.draw(|frame| draw_ui(frame, app))?;
 
         if event::poll(Duration::from_millis(250))? {
-            if let Event::Key(key) = event::read()? {
-                if handle_key(app, key) {
-                    break;
+            match event::read()? {
+                // Only react to key *presses*: with the crossterm 0.29 enhanced
+                // protocol, repeats/releases also arrive and would double every
+                // action (navigation, toggles).
+                Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    if handle_key(app, key) {
+                        break;
+                    }
                 }
+                // Force a full repaint on resize so no stale cells linger.
+                Event::Resize(_, _) => terminal.clear()?,
+                _ => {}
             }
         }
 
@@ -96,9 +104,19 @@ fn handle_key(app: &mut App, key: KeyEvent) -> bool {
                 app.set_view(ViewMode::Diff)
             }
         }
-        KeyCode::Char('v') => {
+        // `v` toggles between disassembly and decompiled code. In the split
+        // diff view it flips which of the two is being diffed instead.
+        KeyCode::Char('v') => match app.view {
+            ViewMode::Diff => app.toggle_diff_kind(),
+            ViewMode::Decompile => app.set_view(ViewMode::Disasm),
+            _ => app.set_view(ViewMode::Decompile),
+        },
+        // `u` switches the diff view between split (side-by-side) and unified
+        // (git-style single column).
+        KeyCode::Char('u') => {
             if app.view == ViewMode::Diff {
-                app.toggle_diff_kind()
+                app.diff_unified = !app.diff_unified;
+                app.scroll = 0;
             }
         }
         _ => {}

--- a/crates/hbc-decomp-cli/src/tui/gitdiff.rs
+++ b/crates/hbc-decomp-cli/src/tui/gitdiff.rs
@@ -1,0 +1,285 @@
+//! Full-program "git" diff: every function's code laid out side by side, base
+//! (file 1) on the left and modified (file 2) on the right, aligned line by
+//! line. Built off-thread because it renders all functions of both files.
+
+use std::collections::HashMap;
+use std::sync::mpsc::{self, Receiver};
+use std::sync::{Arc, OnceLock};
+use std::thread;
+
+use hbc_decomp::{BytecodeFile, BytecodeFormat, DecompileOptionsV2};
+use regex::Regex;
+use similar::{DiffTag, TextDiff};
+
+use super::app::ViewMode;
+use super::diff::DiffStatus;
+use super::{decompile_or_log, disasm_or_log};
+
+/// Canonicalize build-volatile identifiers so that lines differing only by a
+/// Metro module id (e.g. `module_955` vs `module_769`) compare equal and don't
+/// show up as real changes. Used only for the *comparison* — the original text
+/// is still displayed.
+fn normalize(line: &str) -> String {
+    static MODULE: OnceLock<Regex> = OnceLock::new();
+    static REQUIRE: OnceLock<Regex> = OnceLock::new();
+    static DEPMAP: OnceLock<Regex> = OnceLock::new();
+    let module = MODULE.get_or_init(|| Regex::new(r"module_\d+").unwrap());
+    let require = REQUIRE.get_or_init(|| Regex::new(r"require\(\d+\)").unwrap());
+    let depmap = DEPMAP.get_or_init(|| Regex::new(r"dependencyMap\[\d+\]").unwrap());
+    let s = module.replace_all(line, "module_#");
+    let s = require.replace_all(&s, "require(#)");
+    depmap.replace_all(&s, "dependencyMap[#]").into_owned()
+}
+
+/// One aligned side-by-side display row.
+#[derive(Clone)]
+pub enum GitRow {
+    /// Function boundary, shown across both columns.
+    Header(String),
+    /// Unchanged line, present identically on both sides.
+    Same {
+        old: usize,
+        new: usize,
+        text: String,
+    },
+    /// Lines that differ only by volatile ids (e.g. Metro `module_955` vs
+    /// `module_769`) — treated as unchanged, shown without highlight.
+    Cosmetic {
+        old: usize,
+        new: usize,
+        left: String,
+        right: String,
+    },
+    /// Replaced line: different text on each side.
+    Changed {
+        old: usize,
+        new: usize,
+        left: String,
+        right: String,
+    },
+    /// Line only in file 1 (removed).
+    Removed { old: usize, text: String },
+    /// Line only in file 2 (added).
+    Added { new: usize, text: String },
+    /// Blank separator between functions.
+    Blank,
+}
+
+/// Everything the worker needs to render both files. All fields are owned/`Arc`
+/// so the job can move to a background thread.
+pub struct GitDiffJob {
+    pub names: Vec<String>,
+    pub map1: HashMap<String, u32>,
+    pub map2: HashMap<String, u32>,
+    pub diff_status: HashMap<String, DiffStatus>,
+    pub file1: Arc<BytecodeFile>,
+    pub file2: Arc<BytecodeFile>,
+    pub format1: Arc<BytecodeFormat>,
+    pub format2: Arc<BytecodeFormat>,
+    pub kind: ViewMode,
+    /// Ignore volatile Metro ids when deciding what changed.
+    pub normalize: bool,
+}
+
+/// Resolve a function name to its file-2 id, following renames.
+fn id2_for(name: &str, map2: &HashMap<String, u32>, status: &HashMap<String, DiffStatus>) -> Option<u32> {
+    if let Some(id) = map2.get(name) {
+        return Some(*id);
+    }
+    if let Some(DiffStatus::Renamed(new_name)) = status.get(name) {
+        return map2.get(new_name).copied();
+    }
+    None
+}
+
+fn render(file: &BytecodeFile, format: &BytecodeFormat, id: u32, kind: ViewMode) -> String {
+    match kind {
+        ViewMode::Disasm => disasm_or_log(file, format, id),
+        // Decompile per function and stream it: the user sees progress and
+        // content immediately (~0.1s for the first chunk), instead of waiting
+        // seconds for a full pipeline build to finish opaquely.
+        _ => decompile_or_log(file, format, id, &DecompileOptionsV2::optimized()),
+    }
+}
+
+/// Align two function bodies into side-by-side rows. When `normalize_ids` is
+/// set, the comparison ignores volatile Metro ids (lines differing only by an
+/// id become `Cosmetic`, not real changes), but the original text is displayed.
+pub fn align(left: &str, right: &str, normalize_ids: bool) -> Vec<GitRow> {
+    let old_lines: Vec<&str> = left.lines().collect();
+    let new_lines: Vec<&str> = right.lines().collect();
+    // Diff on per-line (optionally normalized) slices, NOT a rejoined string:
+    // from_slices indices map 1:1 onto old_lines/new_lines, so the op ranges are
+    // always valid for display (from_lines can re-tokenize and desync).
+    let key = |l: &&str| {
+        if normalize_ids {
+            normalize(l)
+        } else {
+            (*l).to_string()
+        }
+    };
+    let old_norm: Vec<String> = old_lines.iter().map(key).collect();
+    let new_norm: Vec<String> = new_lines.iter().map(key).collect();
+    let old_ref: Vec<&str> = old_norm.iter().map(String::as_str).collect();
+    let new_ref: Vec<&str> = new_norm.iter().map(String::as_str).collect();
+    let diff = TextDiff::from_slices(&old_ref, &new_ref);
+
+    let mut rows = Vec::new();
+    for op in diff.ops() {
+        match op.tag() {
+            DiffTag::Equal => {
+                for (o, n) in op.old_range().zip(op.new_range()) {
+                    // Equal under normalization: identical, or differs only by id.
+                    if old_lines.get(o).copied().unwrap_or("") == new_lines.get(n).copied().unwrap_or("") {
+                        rows.push(GitRow::Same {
+                            old: o + 1,
+                            new: n + 1,
+                            text: old_lines.get(o).copied().unwrap_or("").to_string(),
+                        });
+                    } else {
+                        rows.push(GitRow::Cosmetic {
+                            old: o + 1,
+                            new: n + 1,
+                            left: old_lines.get(o).copied().unwrap_or("").to_string(),
+                            right: new_lines.get(n).copied().unwrap_or("").to_string(),
+                        });
+                    }
+                }
+            }
+            DiffTag::Delete => {
+                for o in op.old_range() {
+                    rows.push(GitRow::Removed {
+                        old: o + 1,
+                        text: old_lines.get(o).copied().unwrap_or("").to_string(),
+                    });
+                }
+            }
+            DiffTag::Insert => {
+                for n in op.new_range() {
+                    rows.push(GitRow::Added {
+                        new: n + 1,
+                        text: new_lines.get(n).copied().unwrap_or("").to_string(),
+                    });
+                }
+            }
+            DiffTag::Replace => {
+                // Pair left/right lines on the same row; extras spill to
+                // Removed/Added so both columns stay aligned.
+                let olds: Vec<usize> = op.old_range().collect();
+                let news: Vec<usize> = op.new_range().collect();
+                for k in 0..olds.len().max(news.len()) {
+                    match (olds.get(k), news.get(k)) {
+                        (Some(&o), Some(&n)) => rows.push(GitRow::Changed {
+                            old: o + 1,
+                            new: n + 1,
+                            left: old_lines.get(o).copied().unwrap_or("").to_string(),
+                            right: new_lines.get(n).copied().unwrap_or("").to_string(),
+                        }),
+                        (Some(&o), None) => rows.push(GitRow::Removed {
+                            old: o + 1,
+                            text: old_lines.get(o).copied().unwrap_or("").to_string(),
+                        }),
+                        (None, Some(&n)) => rows.push(GitRow::Added {
+                            new: n + 1,
+                            text: new_lines.get(n).copied().unwrap_or("").to_string(),
+                        }),
+                        (None, None) => {}
+                    }
+                }
+            }
+        }
+    }
+    rows
+}
+
+/// Aligned rows for a single function (header + diff + trailing blank).
+fn rows_for_function(job: &GitDiffJob, name: &str) -> Vec<GitRow> {
+    // An empty side means the function is absent there (added/removed), which is
+    // a legitimate diff state — not an error. render() logs real decode errors.
+    let left = match job.map1.get(name) {
+        Some(&id) => render(&job.file1, &job.format1, id, job.kind),
+        None => String::new(),
+    };
+    let right = match id2_for(name, &job.map2, &job.diff_status) {
+        Some(id) => render(&job.file2, &job.format2, id, job.kind),
+        None => String::new(),
+    };
+
+    let mut rows = vec![GitRow::Header(name.to_string())];
+    rows.extend(align(&left, &right, job.normalize));
+    rows.push(GitRow::Blank);
+    rows
+}
+
+/// Whether a row's displayed text contains `query` (which must be lowercase).
+pub fn row_contains(row: &GitRow, query: &str) -> bool {
+    let has = |s: &str| s.to_lowercase().contains(query);
+    match row {
+        GitRow::Header(name) => has(name),
+        GitRow::Same { text, .. } => has(text),
+        GitRow::Cosmetic { left, right, .. } | GitRow::Changed { left, right, .. } => {
+            has(left) || has(right)
+        }
+        GitRow::Removed { text, .. } | GitRow::Added { text, .. } => has(text),
+        GitRow::Blank => false,
+    }
+}
+
+/// Streamed messages from the background git-diff builder. Rows arrive in
+/// chunks so the UI can show and scroll partial results while the rest builds.
+pub enum GitMsg {
+    Chunk {
+        rows: Vec<GitRow>,
+        done: usize,
+        total: usize,
+    },
+    Done,
+}
+
+/// Build the side-by-side rows on a background thread, streaming them in chunks
+/// (decompiling 32k functions of both files takes time).
+pub fn spawn(job: GitDiffJob) -> Receiver<GitMsg> {
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        let total = job.names.len();
+        let mut batch = Vec::new();
+        for (i, name) in job.names.iter().enumerate() {
+            // Contain any panic to a single function so one bad case can't take
+            // down the whole diff build — but log it rather than swallow it.
+            let rows = match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                rows_for_function(&job, name)
+            })) {
+                Ok(rows) => rows,
+                Err(_) => {
+                    super::debug_log(&format!("[gitdiff] panic while rendering '{name}'"));
+                    vec![
+                        GitRow::Header(name.to_string()),
+                        GitRow::Removed {
+                            old: 0,
+                            text: format!("// <panic while rendering '{name}'>"),
+                        },
+                        GitRow::Blank,
+                    ]
+                }
+            };
+            batch.extend(rows);
+            if (i + 1) % 128 == 0 {
+                let msg = GitMsg::Chunk {
+                    rows: std::mem::take(&mut batch),
+                    done: i + 1,
+                    total,
+                };
+                if tx.send(msg).is_err() {
+                    return; // UI gone
+                }
+            }
+        }
+        let _ = tx.send(GitMsg::Chunk {
+            rows: batch,
+            done: total,
+            total,
+        });
+        let _ = tx.send(GitMsg::Done);
+    });
+    rx
+}

--- a/crates/hbc-decomp-cli/src/tui/mod.rs
+++ b/crates/hbc-decomp-cli/src/tui/mod.rs
@@ -11,6 +11,8 @@ use hbc_decomp::{BytecodeFile, BytecodeFormat};
 use ratatui::Terminal;
 
 pub mod app;
+pub mod background;
+pub mod content;
 pub mod diff;
 pub mod events;
 pub mod formatting;

--- a/crates/hbc-decomp-cli/src/tui/mod.rs
+++ b/crates/hbc-decomp-cli/src/tui/mod.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
@@ -16,6 +17,7 @@ pub mod content;
 pub mod diff;
 pub mod events;
 pub mod formatting;
+pub mod gitdiff;
 pub mod ui;
 
 use app::App;
@@ -34,6 +36,37 @@ pub(crate) fn debug_log(message: &str) {
         .open("/tmp/hermes-decomp-tui.log")
     {
         let _ = writeln!(file, "{line}");
+    }
+}
+
+/// Decompile a single function, logging (never silently swallowing) any error
+/// and returning a visible comment instead of an empty string. Used everywhere
+/// the TUI needs per-function code so failures show up in the log and on screen
+/// rather than vanishing into `unwrap_or_default()`.
+pub(crate) fn decompile_or_log(
+    file: &BytecodeFile,
+    format: &BytecodeFormat,
+    id: u32,
+    options: &hbc_decomp::DecompileOptionsV2,
+) -> String {
+    match hbc_decomp::decompile_function_v2(file, format, id, options) {
+        Ok(code) => code,
+        Err(e) => {
+            debug_log(&format!("[decompile] function {id} failed: {e}"));
+            format!("// <decompile error for function {id}: {e}>\n")
+        }
+    }
+}
+
+/// Disassemble a single function, logging any error and returning a visible
+/// comment instead of an empty string.
+pub(crate) fn disasm_or_log(file: &BytecodeFile, format: &BytecodeFormat, id: u32) -> String {
+    match hbc_decomp::disassemble_function(file, format, id, &hbc_decomp::DisasmOptions::default()) {
+        Ok(s) => s,
+        Err(e) => {
+            debug_log(&format!("[disasm] function {id} failed: {e}"));
+            format!("; <disasm error for function {id}: {e}>\n")
+        }
     }
 }
 
@@ -61,7 +94,7 @@ pub fn run_tui(
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen)?;
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
 
     let backend = ratatui::backend::CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
@@ -71,7 +104,11 @@ pub fn run_tui(
     debug_log("[TUI] Event loop exited. Restoring terminal.");
 
     disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )?;
     terminal.show_cursor()?;
 
     result

--- a/crates/hbc-decomp-cli/src/tui/ui.rs
+++ b/crates/hbc-decomp-cli/src/tui/ui.rs
@@ -8,7 +8,7 @@ use super::app::{App, ViewMode};
 use super::diff::DiffStatus;
 
 pub fn draw_ui(frame: &mut Frame, app: &mut App) {
-    let size = frame.size();
+    let size = frame.area();
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -90,7 +90,9 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App) {
             Span::styled("d", Style::default().fg(Color::White)),
             Span::styled(" diff colors ", Style::default().fg(Color::DarkGray)),
             Span::styled("v", Style::default().fg(Color::White)),
-            Span::styled(" toggle asm/code ", Style::default().fg(Color::DarkGray)),
+            Span::styled(" asm/code ", Style::default().fg(Color::DarkGray)),
+            Span::styled("u", Style::default().fg(Color::White)),
+            Span::styled(" split/unified ", Style::default().fg(Color::DarkGray)),
             Span::raw("  "),
             Span::styled("\u{25cf}", Style::default().fg(Color::Green)),
             Span::styled(" added ", Style::default().fg(Color::DarkGray)),

--- a/crates/hbc-decomp-cli/src/tui/ui.rs
+++ b/crates/hbc-decomp-cli/src/tui/ui.rs
@@ -1,13 +1,19 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::widgets::{Block, BorderType, Borders, List, ListItem, Paragraph, Wrap};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph, Wrap};
 use ratatui::Frame;
 
 use super::app::{App, ViewMode};
 use super::diff::DiffStatus;
+use super::formatting::highlight_code;
 
 pub fn draw_ui(frame: &mut Frame, app: &mut App) {
+    if app.git_diff {
+        draw_git_diff(frame, app);
+        return;
+    }
+
     let size = frame.area();
     let layout = Layout::default()
         .direction(Direction::Vertical)
@@ -92,7 +98,7 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App) {
             Span::styled("v", Style::default().fg(Color::White)),
             Span::styled(" asm/code ", Style::default().fg(Color::DarkGray)),
             Span::styled("u", Style::default().fg(Color::White)),
-            Span::styled(" split/unified ", Style::default().fg(Color::DarkGray)),
+            Span::styled(" git diff ", Style::default().fg(Color::DarkGray)),
             Span::raw("  "),
             Span::styled("\u{25cf}", Style::default().fg(Color::Green)),
             Span::styled(" added ", Style::default().fg(Color::DarkGray)),
@@ -186,6 +192,8 @@ fn draw_function_list(frame: &mut Frame, app: &mut App, area: Rect) {
         area
     };
 
+    // Record the inner (content) area so mouse clicks can map to a row.
+    app.list_inner = Block::default().borders(Borders::ALL).inner(list_area);
     frame.render_stateful_widget(list, list_area, &mut app.list_state);
 }
 
@@ -215,4 +223,304 @@ fn draw_content_pane(
         .wrap(Wrap { trim: false })
         .scroll((app.scroll as u16, 0));
     frame.render_widget(paragraph, area);
+}
+
+/// Split `text` into spans, highlighting case-insensitive occurrences of the
+/// (lowercase, ASCII) search query. Falls back to a single plain span.
+fn highlight_spans(text: &str, base: Style, query: Option<&str>) -> Vec<Span<'static>> {
+    let hl = Style::default().fg(Color::Black).bg(Color::Yellow);
+    match query {
+        Some(q) if !q.is_empty() && text.is_ascii() && q.is_ascii() => {
+            let lower = text.to_lowercase();
+            let mut spans = Vec::new();
+            let mut i = 0;
+            while let Some(pos) = lower[i..].find(q) {
+                let s = i + pos;
+                let e = s + q.len();
+                if s > i {
+                    spans.push(Span::styled(text[i..s].to_string(), base));
+                }
+                spans.push(Span::styled(text[s..e].to_string(), hl));
+                i = e;
+            }
+            if i < text.len() {
+                spans.push(Span::styled(text[i..].to_string(), base));
+            }
+            if spans.is_empty() {
+                spans.push(Span::styled(text.to_string(), base));
+            }
+            spans
+        }
+        _ => vec![Span::styled(text.to_string(), base)],
+    }
+}
+
+/// One side of a diff row: git-style sign (`+`/`-`/space), a line-number
+/// gutter, then the text — either syntax-highlighted or diff-tinted, with the
+/// active search term highlighted on top.
+#[allow(clippy::too_many_arguments)]
+fn git_side_line(
+    sign: char,
+    sign_style: Style,
+    line_no: Option<usize>,
+    text: &str,
+    base: Style,
+    query: Option<&str>,
+    syntax: bool,
+) -> Line<'static> {
+    let gutter = match line_no {
+        Some(n) => format!("{n:>5} \u{2502} "),
+        None => "      \u{2502} ".to_string(),
+    };
+    let mut spans = vec![
+        Span::styled(format!("{sign} "), sign_style),
+        Span::styled(gutter, Style::default().fg(Color::DarkGray)),
+    ];
+    if syntax && !text.is_empty() {
+        // Only the visible lines are rendered each frame, so per-line syntax
+        // highlighting here is cheap.
+        match highlight_code(text).into_iter().next() {
+            Some(line) => spans.extend(line.spans),
+            None => spans.push(Span::styled(text.to_string(), base)),
+        }
+    } else {
+        spans.extend(highlight_spans(text, base, query));
+    }
+    Line::from(spans)
+}
+
+/// Full-program git diff: base (file 1) on the left, modified (file 2) on the
+/// right, aligned line by line, both columns scrolled together.
+fn draw_git_diff(frame: &mut Frame, app: &mut App) {
+    use super::gitdiff::GitRow;
+
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // title
+            Constraint::Min(1),    // panes
+            Constraint::Length(1), // footer
+        ])
+        .split(frame.area());
+
+    let kind = match app.git_kind {
+        ViewMode::Disasm => "disassembly",
+        _ => "decompiled",
+    };
+    const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+    let spin = SPINNER[app.tick % SPINNER.len()];
+    let verb = if app.git_kind == ViewMode::Disasm {
+        "disassembling"
+    } else {
+        "decompiling"
+    };
+    let progress = if app.git_computing {
+        let (done, total) = app.git_progress;
+        format!("   {spin} {verb} {done}/{total} functions…")
+    } else {
+        String::new()
+    };
+    // Word-style position feedback: "term [3/324]". The input itself is in the
+    // centered popup while typing.
+    let search = if app.git_search.is_empty() {
+        String::new()
+    } else if app.git_match_count == 0 {
+        format!("   {} [no match]", app.git_search)
+    } else {
+        format!(
+            "   {} [{}/{}]",
+            app.git_search, app.git_match_index, app.git_match_count
+        )
+    };
+    let title = Paragraph::new(Line::from(vec![
+        Span::styled(" Git Diff ", Style::default().fg(Color::Black).bg(Color::Cyan)),
+        Span::raw(format!("  base (file 1) vs modified (file 2) — {kind}")),
+        Span::styled(progress, Style::default().fg(Color::Yellow)),
+        Span::styled(search, Style::default().fg(Color::Cyan)),
+    ]));
+    frame.render_widget(title, outer[0]);
+
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled("u/Esc", Style::default().fg(Color::White)),
+        Span::styled(" back ", Style::default().fg(Color::DarkGray)),
+        Span::styled("j/k wheel", Style::default().fg(Color::White)),
+        Span::styled(" scroll ", Style::default().fg(Color::DarkGray)),
+        Span::styled("/ n/N", Style::default().fg(Color::White)),
+        Span::styled(" search ", Style::default().fg(Color::DarkGray)),
+        Span::styled("click", Style::default().fg(Color::White)),
+        Span::styled(" fold ", Style::default().fg(Color::DarkGray)),
+        Span::styled("v", Style::default().fg(Color::White)),
+        Span::styled(" asm/code ", Style::default().fg(Color::DarkGray)),
+        Span::styled("c", Style::default().fg(Color::White)),
+        Span::styled(
+            if app.git_syntax { " syntax " } else { " plain " },
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled("i", Style::default().fg(Color::White)),
+        Span::styled(
+            if app.git_normalize {
+                " ids:ignored "
+            } else {
+                " ids:shown "
+            },
+            Style::default().fg(Color::DarkGray),
+        ),
+        Span::styled("q", Style::default().fg(Color::White)),
+        Span::styled(" quit", Style::default().fg(Color::DarkGray)),
+    ]));
+    frame.render_widget(footer, outer[2]);
+
+    // Only show a full-screen message until the first chunk arrives; after that
+    // we render (and let the user scroll) the partial result as it streams in.
+    if app.git_rows.is_empty() {
+        let msg = if app.git_computing {
+            let (done, total) = app.git_progress;
+            format!("\n   {spin}  {} bundle… {done}/{total} functions\n\n        Streaming per function — results appear as they finish. Press 'v' to switch asm/code.", if app.git_kind == ViewMode::Disasm { "Disassembling" } else { "Decompiling" })
+        } else {
+            "\n   No diff available yet…".to_string()
+        };
+        frame.render_widget(
+            Paragraph::new(msg).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title(" Loading "),
+            ),
+            outer[1],
+        );
+        return;
+    }
+
+    let cols = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(outer[1]);
+
+    // Visible window (minus the block borders), with scroll clamped. `scroll`
+    // and the window index into git_visible (fold-aware), not git_rows.
+    let height = cols[0].height.saturating_sub(2) as usize;
+    let total = app.git_visible.len();
+    let start = (app.scroll as usize).min(total.saturating_sub(height));
+    app.scroll = start as u32;
+    let end = (start + height).min(total);
+    // Record the columns' content top/height for click-to-fold (both share y).
+    app.git_view_top = cols[0].y + 1;
+    app.git_view_height = height as u16;
+
+    let q_owned = (!app.git_search.is_empty()).then(|| app.git_search.to_lowercase());
+    let q = q_owned.as_deref();
+    let syntax = app.git_syntax;
+    let dim = Style::default().fg(Color::DarkGray);
+    let red = Style::default().fg(Color::Red);
+    let green = Style::default().fg(Color::Green);
+    let plain = Style::default();
+    let blank = || git_side_line(' ', dim, None, "", plain, None, false);
+
+    let mut left_lines: Vec<Line<'static>> = Vec::new();
+    let mut right_lines: Vec<Line<'static>> = Vec::new();
+    for &ri in &app.git_visible[start..end] {
+        match &app.git_rows[ri] {
+            GitRow::Header(name) => {
+                let s = Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD);
+                // ▶ when folded, ▼ when expanded (click the header to toggle).
+                let marker = if app.git_folded.contains(&ri) {
+                    "  \u{25b6} "
+                } else {
+                    "  \u{25bc} "
+                };
+                let mut spans = vec![Span::styled(marker.to_string(), s)];
+                spans.extend(highlight_spans(name, s, q));
+                left_lines.push(Line::from(spans.clone()));
+                right_lines.push(Line::from(spans));
+            }
+            GitRow::Same { old, new, text } => {
+                left_lines.push(git_side_line(' ', dim, Some(*old), text, plain, q, syntax));
+                right_lines.push(git_side_line(' ', dim, Some(*new), text, plain, q, syntax));
+            }
+            // Differs only by a volatile id: shown plainly (not a real change).
+            GitRow::Cosmetic {
+                old,
+                new,
+                left,
+                right,
+            } => {
+                left_lines.push(git_side_line(' ', dim, Some(*old), left, plain, q, syntax));
+                right_lines.push(git_side_line(' ', dim, Some(*new), right, plain, q, syntax));
+            }
+            GitRow::Changed {
+                old,
+                new,
+                left,
+                right,
+            } => {
+                left_lines.push(git_side_line('-', red, Some(*old), left, red, q, syntax));
+                right_lines.push(git_side_line('+', green, Some(*new), right, green, q, syntax));
+            }
+            GitRow::Removed { old, text } => {
+                left_lines.push(git_side_line('-', red, Some(*old), text, red, q, syntax));
+                right_lines.push(blank());
+            }
+            GitRow::Added { new, text } => {
+                left_lines.push(blank());
+                right_lines.push(git_side_line('+', green, Some(*new), text, green, q, syntax));
+            }
+            GitRow::Blank => {
+                left_lines.push(Line::from(""));
+                right_lines.push(Line::from(""));
+            }
+        }
+    }
+
+    frame.render_widget(
+        Paragraph::new(left_lines)
+            .block(Block::default().borders(Borders::ALL).title("file 1 (base)")),
+        cols[0],
+    );
+    frame.render_widget(
+        Paragraph::new(right_lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("file 2 (modified)"),
+        ),
+        cols[1],
+    );
+
+    // Centered search popup while typing.
+    if app.git_searching {
+        let popup = centered_rect(54, 3, frame.area());
+        frame.render_widget(Clear, popup);
+        let count = if app.git_search.is_empty() {
+            String::new()
+        } else if app.git_match_count == 0 {
+            "   no match".to_string()
+        } else {
+            format!("   [{}/{}]", app.git_match_index, app.git_match_count)
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("/", Style::default().fg(Color::Cyan)),
+                Span::raw(app.git_search.clone()),
+                Span::styled("_", Style::default().fg(Color::Cyan)),
+                Span::styled(count, Style::default().fg(Color::Yellow)),
+            ]))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Double)
+                    .title(" Search — \u{2193}/Enter: next  \u{2191}: prev  Esc: close "),
+            ),
+            popup,
+        );
+    }
+}
+
+/// A `Rect` of the given size centered within `area`.
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    Rect {
+        x: area.x + (area.width - w) / 2,
+        y: area.y + (area.height - h) / 2,
+        width: w,
+        height: h,
+    }
 }

--- a/crates/hbc-decomp/build.rs
+++ b/crates/hbc-decomp/build.rs
@@ -56,8 +56,7 @@ fn main() {
         let rel_path = format!("resources/bytecode/Bytecode{version}.json");
         writeln!(
             out_file,
-            "        {version} => Some(include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/\", \"{}\"))),",
-            rel_path
+            "        {version} => Some(include_str!(concat!(env!(\"CARGO_MANIFEST_DIR\"), \"/\", \"{rel_path}\"))),"
         )
         .unwrap();
     }

--- a/crates/hbc-decomp/src/analysis/ipa/inference.rs
+++ b/crates/hbc-decomp/src/analysis/ipa/inference.rs
@@ -65,11 +65,13 @@ pub fn collect_param_names_from_expr(
 
     if !site_results.is_empty() {
         // Flatten the results into a single "site" vector for voting
-        let max_idx = site_results.iter().map(|(idx, _)| *idx).max().unwrap_or(0);
-        let mut site = vec![None; max_idx as usize + 1];
+        let max_idx = (site_results.iter().map(|(idx, _)| *idx).max().unwrap_or(0) as usize)
+            .min(super::MAX_PARAM_SLOTS);
+        let mut site = vec![None; max_idx + 1];
         for (idx, name) in site_results {
-            if site[idx as usize].is_none() {
-                site[idx as usize] = Some(name);
+            let idx = idx as usize;
+            if idx < site.len() && site[idx].is_none() {
+                site[idx] = Some(name);
             }
         }
         self_param_names.entry(owner_id).or_default().push(site);

--- a/crates/hbc-decomp/src/analysis/ipa/mod.rs
+++ b/crates/hbc-decomp/src/analysis/ipa/mod.rs
@@ -12,6 +12,12 @@ use crate::ir::Statement;
 use graph::CallGraph;
 use inference::{is_generic_name, vote_on_names};
 use std::collections::BTreeMap;
+
+/// Upper bound on parameter-slot vectors. Parameter indices come from parsed
+/// IR; a corrupt index could otherwise drive `vec![None; idx + 1]` / `resize`
+/// to allocate gigabytes and abort the process. No real function approaches
+/// this many parameters.
+pub(crate) const MAX_PARAM_SLOTS: usize = 1 << 16;
 pub use structs::GlobalAnalysis;
 pub use resolution::FunctionNameIndex;
 
@@ -54,8 +60,10 @@ pub fn run_ipa(
     for (&func_id, stmts) in functions {
         let body_hints = body_hints::infer_param_names_from_body(stmts);
         if !body_hints.is_empty() {
-            let max_idx = body_hints.iter().map(|(idx, _)| *idx).max().unwrap_or(0);
-            let mut site = vec![None; max_idx as usize + 1];
+            let max_idx =
+                (body_hints.iter().map(|(idx, _)| *idx).max().unwrap_or(0) as usize)
+                    .min(MAX_PARAM_SLOTS);
+            let mut site = vec![None; max_idx + 1];
             for (idx, name) in body_hints {
                 if site.get(idx as usize).is_none_or(|s| s.is_none())
                     && idx < site.len() as u32 {
@@ -109,6 +117,9 @@ pub fn run_ipa(
 
         if let Some(links) = links_by_src.get(&func_id) {
             for link in links {
+                if link.dst_param as usize >= MAX_PARAM_SLOTS {
+                    continue;
+                }
                 if let Some(Some(name)) = src_names.get(link.src_param as usize) {
                     let entry = analysis.param_names.entry(link.dst_func).or_default();
                     if entry.len() <= link.dst_param as usize {
@@ -133,6 +144,9 @@ pub fn run_ipa(
 
         if let Some(links) = links_by_dst.get(&func_id) {
             for link in links {
+                if link.src_param as usize >= MAX_PARAM_SLOTS {
+                    continue;
+                }
                 if let Some(Some(name)) = dst_names.get(link.dst_param as usize) {
                     let entry = analysis.param_names.entry(link.src_func).or_default();
                     if entry.len() <= link.src_param as usize {

--- a/crates/hbc-decomp/src/analysis/metro/propagation/mod.rs
+++ b/crates/hbc-decomp/src/analysis/metro/propagation/mod.rs
@@ -149,7 +149,7 @@ pub fn propagate_module_names(
     // Count how many modules have names now
     let named_total = registry.modules.values().filter(|m| m.name.is_some()).count();
     let total = registry.modules.len();
-    eprintln!("[pipeline] module naming: {named_total}/{total} named ({inferred_count} inferred, {reexport_count} re-export)");
+    log::debug!("[pipeline] module naming: {named_total}/{total} named ({inferred_count} inferred, {reexport_count} re-export)");
 
     // PHASE 1: Detect closure_N = require(id) and propagate module names to closure slots
     propagate_module_names_to_closures(functions, registry, closure_ctx);

--- a/crates/hbc-decomp/src/analysis/metro/propagation/phases.rs
+++ b/crates/hbc-decomp/src/analysis/metro/propagation/phases.rs
@@ -134,7 +134,7 @@ pub(super) fn reverse_require_naming(
     }
 
     if named_count > 0 {
-        eprintln!("[pipeline] reverse require naming: {named_count} modules named");
+        log::debug!("[pipeline] reverse require naming: {named_count} modules named");
     }
 }
 

--- a/crates/hbc-decomp/src/debug.rs
+++ b/crates/hbc-decomp/src/debug.rs
@@ -304,40 +304,70 @@ mod tests {
         assert!(info.scope_descriptors.is_empty());
     }
 
-    /// Build a minimal but well-formed debug section (7-field header, no
-    /// filenames/regions) wrapping the given debug-data blob, returning the
-    /// full byte buffer and the offset to pass to `DebugInfo::parse`.
-    fn wrap_debug_section(
-        data: &[u8],
-        scope_desc_offset: u32,
-        textified_callee_offset: u32,
-        string_table_offset: u32,
+    /// Build a complete, well-formed Hermes debug section: the 7-field header, a
+    /// real filename table (`{offset,length}` entries + concatenated storage)
+    /// and a file-region table, then the debug-data blob (scope descriptors,
+    /// textified callees, string table). This lays the section out exactly like
+    /// a real bundle, so it exercises the data-start arithmetic
+    /// (`28 + 8*filenameCount + filenameStorageSize + 12*fileRegionCount`) —
+    /// not a degenerate empty-table shortcut. The section offsets are derived
+    /// from the actual blob sizes. Returns (full buffer, offset for `parse`).
+    fn build_debug_section(
+        filenames: &[&str],
+        file_regions: u32,
+        scope_data: &[u8],
+        callee_data: &[u8],
+        string_table: &[u8],
     ) -> (Vec<u8>, u32) {
+        // Filename table: an {offset, length} pair per name, then the storage.
+        let mut storage = Vec::new();
+        let mut entries = Vec::new();
+        for name in filenames {
+            entries.push((storage.len() as u32, name.len() as u32));
+            storage.extend_from_slice(name.as_bytes());
+        }
+
+        // Offsets are relative to the start of the debug-data blob.
+        let scope_off = 0u32;
+        let callee_off = scope_data.len() as u32;
+        let string_off = callee_off + callee_data.len() as u32;
+        let data_size = string_off + string_table.len() as u32;
+
         let mut bytes = vec![0u8; 4]; // prefix so the offset is non-zero
         for v in [
-            0u32, // filename_count
-            0,    // filename_storage_size
-            0,    // file_region_count
-            scope_desc_offset,
-            textified_callee_offset,
-            string_table_offset,
-            data.len() as u32, // debug_data_size
+            filenames.len() as u32,
+            storage.len() as u32,
+            file_regions,
+            scope_off,
+            callee_off,
+            string_off,
+            data_size,
         ] {
             bytes.extend_from_slice(&v.to_le_bytes());
         }
-        bytes.extend_from_slice(data); // debug data starts at prefix(4) + header(28) = 32
+        // Filename table: entries, then storage.
+        for (off, len) in &entries {
+            bytes.extend_from_slice(&off.to_le_bytes());
+            bytes.extend_from_slice(&len.to_le_bytes());
+        }
+        bytes.extend_from_slice(&storage);
+        // File regions: file_regions * 12 bytes (contents irrelevant here).
+        bytes.extend(vec![0u8; file_regions as usize * 12]);
+        // Debug data: scope descriptors, callees, string table.
+        bytes.extend_from_slice(scope_data);
+        bytes.extend_from_slice(callee_data);
+        bytes.extend_from_slice(string_table);
         (bytes, 4)
     }
 
     #[test]
-    fn test_parses_scope_names_by_index() {
-        // data: [scope desc | string table]. One scope: parent=-1 (0x7f),
-        // flags=0, name_count=1, name_idx=0 -> "hi".
-        let data = [
-            0x7f, 0x00, 0x01, 0x00, // scope desc (offsets 0..4)
-            0x02, b'h', b'i', // string table (offsets 4..7): one string "hi"
-        ];
-        let (bytes, off) = wrap_debug_section(&data, 0, 4, 4);
+    fn test_parses_real_section_with_filenames_and_regions() {
+        // One scope: parent=-1 (0x7f), flags=0, name_count=1, name_idx=0 -> "hi".
+        let scope = [0x7f, 0x00, 0x01, 0x00];
+        let strings = [0x02, b'h', b'i']; // string table: one entry "hi"
+        // Two filenames + one file region so data_start =
+        // 28 + 8*2 + len("app.js"=6)+len("b.js"=4) + 12*1 = 28+16+10+12 = 66.
+        let (bytes, off) = build_debug_section(&["app.js", "b.js"], 1, &scope, &[], &strings);
         let info = DebugInfo::parse(&bytes, off).unwrap();
         assert_eq!(info.string_table, vec!["hi".to_string()]);
         assert_eq!(info.scope_descriptors.len(), 1);
@@ -351,9 +381,9 @@ mod tests {
     // clean result instead, never panicking, for any input.
     #[test]
     fn test_malformed_debug_info_never_panics() {
-        // Poison name_count (-1) in the scope region.
-        let data = [0x7f, 0x00, 0x7f]; // parent=-1, flags=0, name_count=-1
-        let (bytes, off) = wrap_debug_section(&data, 0, 3, 3);
+        // Poison name_count (-1) in the scope region of an otherwise valid section.
+        let scope = [0x7f, 0x00, 0x7f]; // parent=-1, flags=0, name_count=-1
+        let (bytes, off) = build_debug_section(&["a.js"], 1, &scope, &[], &[]);
         let info = DebugInfo::parse(&bytes, off).expect("must not panic");
         assert!(info.scope_descriptors.is_empty());
 

--- a/crates/hbc-decomp/src/debug.rs
+++ b/crates/hbc-decomp/src/debug.rs
@@ -7,6 +7,23 @@ use crate::error::Result;
 use crate::io::ByteReader;
 use std::collections::BTreeMap;
 
+/// `data[start..start+len]` if fully in bounds, else `None`. Uses u64 so huge
+/// header values can't overflow the index arithmetic.
+fn slice_in_bounds(data: &[u8], start: u64, len: u64) -> Option<&[u8]> {
+    let start = usize::try_from(start).ok()?;
+    let len = usize::try_from(len).ok()?;
+    let end = start.checked_add(len)?;
+    data.get(start..end)
+}
+
+/// `data[start..end]` if `start <= end <= data.len()`, else `None`.
+fn slice_range(data: &[u8], start: u32, end: u32) -> Option<&[u8]> {
+    if start > end {
+        return None;
+    }
+    data.get(start as usize..end as usize)
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct DebugInfo {
     pub source_locations: BTreeMap<u32, Vec<SourceLocation>>,
@@ -41,11 +58,30 @@ impl ScopeDescriptor {
     }
 }
 
+/// Parsed Hermes `DebugInfoHeader` (7 little-endian u32 fields).
+///
+/// The section layout is:
+///   [DebugInfoHeader (28 bytes)]
+///   [filename table: filename_count * 8 bytes ({offset,length}) + filename_storage_size bytes]
+///   [file regions:   file_region_count * 12 bytes]
+///   [debug data (debug_data_size bytes):
+///       [0 .. scope_desc_offset)             source-location / line data
+///       [scope_desc_offset .. callee_offset) scope descriptors
+///       [callee_offset .. string_offset)     textified callees
+///       [string_offset .. debug_data_size)   debug string table ]
+///
+/// The three offsets are relative to the START OF THE DEBUG DATA, not to the
+/// section start — a distinction the old 3-field reader got wrong, which is the
+/// root cause of issue #4 (it read the filename/region counts as offsets).
 #[derive(Debug, Clone)]
-struct DebugInfoOffsets {
+struct DebugInfoHeader {
+    filename_count: u32,
+    filename_storage_size: u32,
+    file_region_count: u32,
     scope_desc_offset: u32,
     textified_callee_offset: u32,
     string_table_offset: u32,
+    debug_data_size: u32,
 }
 
 impl DebugInfo {
@@ -60,52 +96,76 @@ impl DebugInfo {
         }
 
         let mut reader = ByteReader::new(&bytes[offset..]);
+        let header = Self::parse_header(&mut reader)?;
 
-        let offsets = Self::parse_header(&mut reader)?;
+        // Where the debug-data blob begins, relative to the section start.
+        // Every term is bounded by header values; use u64 + saturating math so
+        // a corrupt header can never overflow or index out of range.
+        let data_start = 28u64
+            + (header.filename_count as u64).saturating_mul(8)
+            + header.filename_storage_size as u64
+            + (header.file_region_count as u64).saturating_mul(12);
+        let section = &bytes[offset..];
+        let Some(data) = slice_in_bounds(section, data_start, header.debug_data_size as u64) else {
+            // Header points past the file: treat as "no debug info" rather than
+            // failing the whole bytecode parse.
+            return Ok(Self::default());
+        };
 
         let mut debug_info = DebugInfo::default();
-        if offsets.scope_desc_offset < offsets.textified_callee_offset {
-            let scope_start = offsets.scope_desc_offset as usize;
-            let scope_end = offsets.textified_callee_offset as usize;
-            if scope_start < bytes.len() - offset && scope_end <= bytes.len() - offset {
-                let scope_data = &bytes[offset + scope_start..offset + scope_end];
-                debug_info.scope_descriptors = Self::parse_scope_descriptors(scope_data)?;
-            }
+
+        // Parse the string table first: scope descriptors and callees refer to
+        // their names by index into it.
+        if let Some(table) = slice_range(
+            data,
+            header.string_table_offset,
+            header.debug_data_size,
+        ) {
+            debug_info.string_table = Self::parse_string_table(table);
         }
 
-        if offsets.textified_callee_offset < offsets.string_table_offset {
-            let callee_start = offsets.textified_callee_offset as usize;
-            let callee_end = offsets.string_table_offset as usize;
-            if callee_start < bytes.len() - offset && callee_end <= bytes.len() - offset {
-                let callee_data = &bytes[offset + callee_start..offset + callee_end];
-                debug_info.textified_callees = Self::parse_textified_callees(callee_data)?;
-            }
+        if let Some(scope_data) = slice_range(
+            data,
+            header.scope_desc_offset,
+            header.textified_callee_offset,
+        ) {
+            debug_info.scope_descriptors =
+                Self::parse_scope_descriptors(scope_data, &debug_info.string_table);
         }
 
-        if offsets.string_table_offset < (bytes.len() - offset) as u32 {
-            let table_start = offsets.string_table_offset as usize;
-            if table_start < bytes.len() - offset {
-                let table_data = &bytes[offset + table_start..];
-                debug_info.string_table = Self::parse_string_table(table_data)?;
-            }
+        if let Some(callee_data) = slice_range(
+            data,
+            header.textified_callee_offset,
+            header.string_table_offset,
+        ) {
+            debug_info.textified_callees =
+                Self::parse_textified_callees(callee_data, &debug_info.string_table);
         }
 
         Ok(debug_info)
     }
 
-    fn parse_header(reader: &mut ByteReader<'_>) -> Result<DebugInfoOffsets> {
-        let scope_desc_offset = reader.read_u32()?;
-        let textified_callee_offset = reader.read_u32()?;
-        let string_table_offset = reader.read_u32()?;
-
-        Ok(DebugInfoOffsets {
-            scope_desc_offset,
-            textified_callee_offset,
-            string_table_offset,
+    fn parse_header(reader: &mut ByteReader<'_>) -> Result<DebugInfoHeader> {
+        Ok(DebugInfoHeader {
+            filename_count: reader.read_u32()?,
+            filename_storage_size: reader.read_u32()?,
+            file_region_count: reader.read_u32()?,
+            scope_desc_offset: reader.read_u32()?,
+            textified_callee_offset: reader.read_u32()?,
+            string_table_offset: reader.read_u32()?,
+            debug_data_size: reader.read_u32()?,
         })
     }
 
-    fn parse_scope_descriptors(data: &[u8]) -> Result<Vec<ScopeDescriptor>> {
+    /// Resolve a debug-string-table index to its name, if in range.
+    fn name_at(table: &[String], index: i64) -> Option<String> {
+        usize::try_from(index)
+            .ok()
+            .and_then(|i| table.get(i))
+            .cloned()
+    }
+
+    fn parse_scope_descriptors(data: &[u8], strings: &[String]) -> Vec<ScopeDescriptor> {
         let mut descriptors = Vec::new();
         let mut reader = ByteReader::new(data);
         let mut current_offset = 0u32;
@@ -113,82 +173,85 @@ impl DebugInfo {
         while reader.remaining() > 0 {
             let start_pos = reader.position();
 
-            let parent_raw = reader.read_sleb128()?;
-            let parent_offset = if parent_raw < 0 {
+            // A malformed/mis-aligned section can desync here; bail on the first
+            // read error or implausible count rather than panic or loop wildly.
+            let Ok(parent_raw) = reader.read_sleb128() else {
+                break;
+            };
+            let Ok(flags) = reader.read_sleb128() else {
+                break;
+            };
+            let Ok(name_count) = reader.read_sleb128() else {
+                break;
+            };
+            if !(0..=reader.remaining() as i64).contains(&name_count) {
+                break;
+            }
+
+            let mut names = Vec::new();
+            for _ in 0..name_count {
+                let Ok(name_idx) = reader.read_sleb128() else {
+                    break;
+                };
+                // Out-of-range index => unknown name (empty) rather than wrong.
+                names.push(Self::name_at(strings, name_idx).unwrap_or_default());
+            }
+
+            // Hermes encodes "no parent" as the u32 sentinel (all ones).
+            let parent_offset = if parent_raw < 0 || parent_raw >= u32::MAX as i64 {
                 None
             } else {
                 Some(parent_raw as u32)
             };
 
-            let flags = reader.read_sleb128()? as u32;
-
-            let name_count = reader.read_sleb128()? as usize;
-
-            let mut names = Vec::with_capacity(name_count);
-            for _ in 0..name_count {
-                let name = reader.read_length_prefixed_string()?;
-                names.push(name);
-            }
-
             descriptors.push(ScopeDescriptor {
                 offset: current_offset,
                 parent_offset,
-                flags,
+                flags: flags as u32,
                 names,
             });
 
             current_offset += (reader.position() - start_pos) as u32;
         }
 
-        Ok(descriptors)
+        descriptors
     }
 
-    fn parse_textified_callees(data: &[u8]) -> Result<BTreeMap<u32, String>> {
+    fn parse_textified_callees(data: &[u8], strings: &[String]) -> BTreeMap<u32, String> {
         let mut callees = BTreeMap::new();
         let mut reader = ByteReader::new(data);
 
-        if reader.remaining() == 0 {
-            return Ok(callees);
+        let Ok(count) = reader.read_sleb128() else {
+            return callees;
+        };
+        if !(0..=reader.remaining() as i64).contains(&count) {
+            return callees;
         }
-
-        let count = reader.read_sleb128()? as usize;
 
         for _ in 0..count {
-            if reader.remaining() == 0 {
+            let (Ok(address), Ok(name_idx)) = (reader.read_sleb128(), reader.read_sleb128()) else {
                 break;
+            };
+            if let Some(name) = Self::name_at(strings, name_idx) {
+                callees.insert(address as u32, name);
             }
-            let address = reader.read_sleb128()? as u32;
-            let name = reader.read_length_prefixed_string()?;
-            callees.insert(address, name);
         }
 
-        Ok(callees)
+        callees
     }
 
-    fn parse_string_table(data: &[u8]) -> Result<Vec<String>> {
+    /// The debug string table is a run of length-prefixed strings filling the
+    /// region — there is no leading count.
+    fn parse_string_table(data: &[u8]) -> Vec<String> {
         let mut strings = Vec::new();
         let mut reader = ByteReader::new(data);
-
-        if reader.remaining() == 0 {
-            return Ok(strings);
-        }
-
-        let count = match reader.read_sleb128() {
-            Ok(c) if c >= 0 => c as usize,
-            _ => return Ok(strings),
-        };
-
-        for _ in 0..count {
-            if reader.remaining() == 0 {
-                break;
-            }
+        while reader.remaining() > 0 {
             match reader.read_length_prefixed_string() {
                 Ok(s) => strings.push(s),
                 Err(_) => break,
             }
         }
-
-        Ok(strings)
+        strings
     }
 
     pub fn build_variable_map(&self, function_scope_offset: Option<u32>) -> BTreeMap<u32, String> {
@@ -239,5 +302,66 @@ mod tests {
     fn test_invalid_offset() {
         let info = DebugInfo::parse(&[0u8; 100], u32::MAX).unwrap();
         assert!(info.scope_descriptors.is_empty());
+    }
+
+    /// Build a minimal but well-formed debug section (7-field header, no
+    /// filenames/regions) wrapping the given debug-data blob, returning the
+    /// full byte buffer and the offset to pass to `DebugInfo::parse`.
+    fn wrap_debug_section(
+        data: &[u8],
+        scope_desc_offset: u32,
+        textified_callee_offset: u32,
+        string_table_offset: u32,
+    ) -> (Vec<u8>, u32) {
+        let mut bytes = vec![0u8; 4]; // prefix so the offset is non-zero
+        for v in [
+            0u32, // filename_count
+            0,    // filename_storage_size
+            0,    // file_region_count
+            scope_desc_offset,
+            textified_callee_offset,
+            string_table_offset,
+            data.len() as u32, // debug_data_size
+        ] {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        bytes.extend_from_slice(data); // debug data starts at prefix(4) + header(28) = 32
+        (bytes, 4)
+    }
+
+    #[test]
+    fn test_parses_scope_names_by_index() {
+        // data: [scope desc | string table]. One scope: parent=-1 (0x7f),
+        // flags=0, name_count=1, name_idx=0 -> "hi".
+        let data = [
+            0x7f, 0x00, 0x01, 0x00, // scope desc (offsets 0..4)
+            0x02, b'h', b'i', // string table (offsets 4..7): one string "hi"
+        ];
+        let (bytes, off) = wrap_debug_section(&data, 0, 4, 4);
+        let info = DebugInfo::parse(&bytes, off).unwrap();
+        assert_eq!(info.string_table, vec!["hi".to_string()]);
+        assert_eq!(info.scope_descriptors.len(), 1);
+        assert_eq!(info.scope_descriptors[0].names, vec!["hi".to_string()]);
+        assert_eq!(info.scope_descriptors[0].parent_offset, None);
+    }
+
+    // Regression for issue #4: a mis-located/short debug section (as happens on
+    // v96 bundles) used to decode an absurd name count and panic in
+    // Vec::with_capacity ("capacity overflow"). Parsing must now degrade to a
+    // clean result instead, never panicking, for any input.
+    #[test]
+    fn test_malformed_debug_info_never_panics() {
+        // Poison name_count (-1) in the scope region.
+        let data = [0x7f, 0x00, 0x7f]; // parent=-1, flags=0, name_count=-1
+        let (bytes, off) = wrap_debug_section(&data, 0, 3, 3);
+        let info = DebugInfo::parse(&bytes, off).expect("must not panic");
+        assert!(info.scope_descriptors.is_empty());
+
+        // Arbitrary garbage offsets / truncated buffers must not panic either.
+        for len in [0usize, 1, 8, 28, 40] {
+            let junk = vec![0xffu8; len];
+            let _ = DebugInfo::parse(&junk, 1);
+            let _ = DebugInfo::parse(&junk, len as u32);
+        }
     }
 }

--- a/crates/hbc-decomp/src/disasm.rs
+++ b/crates/hbc-decomp/src/disasm.rs
@@ -99,13 +99,13 @@ pub fn collect_label_offsets(
             None => continue,
         };
         if def.name == "Ret" || def.name == "Throw" || def.name == "Jmp" || def.name == "JmpLong" {
-            labels.insert(insn.offset + insn.length);
+            labels.insert(insn.offset.wrapping_add(insn.length));
         }
         if def.is_jump {
             for operand in &insn.operands {
                 if operand.ty == OperandType::Addr8 || operand.ty == OperandType::Addr32 {
                     if let Some(rel) = operand.value.as_i32() {
-                        let target = insn.offset as i32 + rel;
+                        let target = (insn.offset as i32).wrapping_add(rel);
                         if target >= 0 {
                             labels.insert(target as u32);
                         }
@@ -182,7 +182,7 @@ fn format_operand(
         OperandType::Addr8 | OperandType::Addr32 => {
             let s = match operand.value.as_i32() {
                 Some(rel) => {
-                    let target = insn.offset as i32 + rel;
+                    let target = (insn.offset as i32).wrapping_add(rel);
                     format!("L{target}")
                 }
                 None => "L?".to_string(),

--- a/crates/hbc-decomp/src/file/parser/buffer.rs
+++ b/crates/hbc-decomp/src/file/parser/buffer.rs
@@ -33,7 +33,7 @@ pub fn read_buffer_series(
     }
 
     let mut reader = ByteReader::new(&buffer[offset as usize..]);
-    let mut values = Vec::with_capacity(count as usize);
+    let mut values = Vec::with_capacity(reader.capacity_hint(count as usize));
 
     while values.len() < count as usize {
         let (tag, length) = read_buffer_tag(&mut reader)?;

--- a/crates/hbc-decomp/src/file/parser/function.rs
+++ b/crates/hbc-decomp/src/file/parser/function.rs
@@ -9,7 +9,7 @@ pub fn parse_function_headers(
     reader: &mut ByteReader<'_>,
     header: &BytecodeHeader,
 ) -> Result<Vec<FunctionHeader>> {
-    let mut headers = Vec::with_capacity(header.function_count as usize);
+    let mut headers = Vec::with_capacity(reader.capacity_hint(header.function_count as usize));
     for function_id in 0..header.function_count {
         let current_pos = reader.position();
         let function_header = match header.function_header_layout {

--- a/crates/hbc-decomp/src/file/parser/helpers.rs
+++ b/crates/hbc-decomp/src/file/parser/helpers.rs
@@ -7,7 +7,7 @@ use crate::file::{BytecodeFile, LiteralValue};
 pub fn bigint_at(file: &BytecodeFile, bigint_id: u32) -> Option<String> {
     let entry = file.big_int_table.get(bigint_id as usize)?;
     let start = entry.offset as usize;
-    let end = start + entry.length as usize;
+    let end = start.checked_add(entry.length as usize)?;
 
     if end > file.big_int_storage.len() {
         return None;

--- a/crates/hbc-decomp/src/file/parser/instructions.rs
+++ b/crates/hbc-decomp/src/file/parser/instructions.rs
@@ -20,7 +20,9 @@ pub fn decode_function_instructions(
 
     let size = header.bytecode_size_in_bytes() as usize;
     let start = func_offset as usize;
-    let end = start + size;
+    let end = start.checked_add(size).ok_or_else(|| {
+        Error::Parse(format!("function {function_id} bytecode offset overflow"))
+    })?;
     if end > file.instructions.len() {
         return Err(Error::Parse(format!(
             "function {function_id} bytecode out of range"

--- a/crates/hbc-decomp/src/file/parser/parsing.rs
+++ b/crates/hbc-decomp/src/file/parser/parsing.rs
@@ -50,7 +50,7 @@ fn track_section<T>(
     sections.push(SectionInfo {
         name,
         offset: sec_start,
-        size: reader.position() as u32 - sec_start,
+        size: (reader.position() as u32).saturating_sub(sec_start),
         entries,
     });
     Ok(result)
@@ -290,7 +290,7 @@ fn parse_trailing_and_build(
     sections.push(SectionInfo {
         name: "bytecode",
         offset: instruction_offset,
-        size: bytes.len() as u32 - instruction_offset,
+        size: (bytes.len() as u32).saturating_sub(instruction_offset),
         entries: None,
     });
 
@@ -354,8 +354,8 @@ fn parse_exception_handlers(
         }
 
         // Align to 4 bytes
-        let aligned = (info_offset + 3) & !3;
-        if aligned + 4 > bytes.len() {
+        let aligned = info_offset.saturating_add(3) & !3;
+        if aligned.saturating_add(4) > bytes.len() {
             continue;
         }
 

--- a/crates/hbc-decomp/src/file/parser/table.rs
+++ b/crates/hbc-decomp/src/file/parser/table.rs
@@ -5,7 +5,7 @@ use crate::file::structure::{
 use crate::io::ByteReader;
 
 pub fn parse_string_kinds(reader: &mut ByteReader<'_>, count: u32) -> Result<Vec<StringKindEntry>> {
-    let mut entries = Vec::with_capacity(count as usize);
+    let mut entries = Vec::with_capacity(reader.capacity_hint(count as usize));
     for _ in 0..count {
         let raw = reader.read_u32()?;
         let kind = if (raw & (1 << 31)) == 0 {
@@ -23,7 +23,7 @@ pub fn parse_overflow_string_table(
     reader: &mut ByteReader<'_>,
     count: u32,
 ) -> Result<Vec<(u32, u32)>> {
-    let mut entries = Vec::with_capacity(count as usize);
+    let mut entries = Vec::with_capacity(reader.capacity_hint(count as usize));
     for _ in 0..count {
         let offset = reader.read_u32()?;
         let length = reader.read_u32()?;
@@ -33,7 +33,7 @@ pub fn parse_overflow_string_table(
 }
 
 pub fn parse_u32_vec(reader: &mut ByteReader<'_>, count: u32) -> Result<Vec<u32>> {
-    let mut values = Vec::with_capacity(count as usize);
+    let mut values = Vec::with_capacity(reader.capacity_hint(count as usize));
     for _ in 0..count {
         values.push(reader.read_u32()?);
     }
@@ -41,7 +41,7 @@ pub fn parse_u32_vec(reader: &mut ByteReader<'_>, count: u32) -> Result<Vec<u32>
 }
 
 pub fn parse_table_entries(reader: &mut ByteReader<'_>, count: u32) -> Result<Vec<TableEntry>> {
-    let mut entries = Vec::with_capacity(count as usize);
+    let mut entries = Vec::with_capacity(reader.capacity_hint(count as usize));
     for _ in 0..count {
         let offset = reader.read_u32()?;
         let length = reader.read_u32()?;
@@ -51,7 +51,7 @@ pub fn parse_table_entries(reader: &mut ByteReader<'_>, count: u32) -> Result<Ve
 }
 
 pub fn parse_shape_table(reader: &mut ByteReader<'_>, count: u32) -> Result<Vec<ShapeTableEntry>> {
-    let mut entries = Vec::with_capacity(count as usize);
+    let mut entries = Vec::with_capacity(reader.capacity_hint(count as usize));
     for _ in 0..count {
         let key_buffer_offset = reader.read_u32()?;
         let num_props = reader.read_u32()?;
@@ -64,7 +64,7 @@ pub fn parse_shape_table(reader: &mut ByteReader<'_>, count: u32) -> Result<Vec<
 }
 
 pub fn parse_pair_table(reader: &mut ByteReader<'_>, count: u32) -> Result<Vec<(u32, u32)>> {
-    let mut entries = Vec::with_capacity(count as usize);
+    let mut entries = Vec::with_capacity(reader.capacity_hint(count as usize));
     for _ in 0..count {
         let first = reader.read_u32()?;
         let second = reader.read_u32()?;
@@ -80,11 +80,15 @@ pub fn decode_string_table(
     overflow_entries: &[(u32, u32)],
     storage: &[u8],
 ) -> Result<Vec<StringTableEntry>> {
-    let mut expanded_kinds = Vec::with_capacity(string_count as usize);
+    // A corrupt or mis-read header can carry a string_count far larger than the
+    // actual small-entry table; clamp so both the allocations and the loops
+    // below stay bounded (for valid files the two are equal anyway).
+    let count = (string_count as usize).min(small_entries.len());
+    let mut expanded_kinds = Vec::with_capacity(count);
     let mut kind_index = 0usize;
     let mut remaining = kinds.first().map(|k| k.count).unwrap_or(0);
 
-    for _ in 0..string_count {
+    for _ in 0..count {
         if remaining == 0 {
             kind_index += 1;
             remaining = kinds.get(kind_index).map(|k| k.count).unwrap_or(0);
@@ -97,10 +101,10 @@ pub fn decode_string_table(
         remaining = remaining.saturating_sub(1);
     }
 
-    let mut strings = Vec::with_capacity(string_count as usize);
+    let mut strings = Vec::with_capacity(count);
     let mut overflow_index = 0usize;
 
-    for i in 0..string_count as usize {
+    for i in 0..count {
         let raw = small_entries
             .get(i)
             .copied()

--- a/crates/hbc-decomp/src/file/parser/table.rs
+++ b/crates/hbc-decomp/src/file/parser/table.rs
@@ -126,11 +126,12 @@ pub fn decode_string_table(
         };
 
         let value = if is_utf16 {
-            let byte_len = (length as usize) * 2;
+            // saturating math: an overflowing offset/length just fails the
+            // bounds check below and yields "<invalid>" instead of panicking.
+            let byte_len = (length as usize).saturating_mul(2);
             let start = offset as usize;
-            let end = start + byte_len;
+            let end = start.saturating_add(byte_len);
 
-            // Check bounds strictly to safely panic/error if out of bounds
             if start >= storage.len() || end > storage.len() {
                 "<invalid utf16>".to_string()
             } else {
@@ -143,7 +144,7 @@ pub fn decode_string_table(
             }
         } else {
             let start = offset as usize;
-            let end = start + length as usize;
+            let end = start.saturating_add(length as usize);
             if start >= storage.len() || end > storage.len() {
                 "<invalid utf8>".to_string()
             } else {

--- a/crates/hbc-decomp/src/io.rs
+++ b/crates/hbc-decomp/src/io.rs
@@ -18,6 +18,18 @@ impl<'a> ByteReader<'a> {
         self.data.len().saturating_sub(self.pos)
     }
 
+    /// A safe pre-allocation hint for `count` upcoming entries.
+    ///
+    /// A corrupt or mis-read header can carry an absurd count (up to
+    /// `u32::MAX`, or a negative SLEB128 cast to `usize`). Feeding that
+    /// straight to `Vec::with_capacity` aborts the process with "capacity
+    /// overflow". Since every entry consumes at least one byte, the count can
+    /// never validly exceed the bytes left to read, so we clamp to that. Valid
+    /// files (where `count <= remaining`) keep their exact-size pre-allocation.
+    pub fn capacity_hint(&self, count: usize) -> usize {
+        count.min(self.remaining())
+    }
+
     pub fn seek(&mut self, pos: usize) -> Result<()> {
         if pos > self.data.len() {
             return Err(Error::Parse(format!(
@@ -83,15 +95,19 @@ impl<'a> ByteReader<'a> {
     }
 
     fn read_exact(&mut self, len: usize) -> Result<&'a [u8]> {
-        if self.pos + len > self.data.len() {
+        // checked_add so a huge `len` (e.g. a bogus length prefix) can't wrap
+        // past the bounds check and cause an out-of-bounds slice panic.
+        let end = self.pos.checked_add(len).filter(|&e| e <= self.data.len());
+        let Some(end) = end else {
             return Err(Error::Parse(format!(
-                "unexpected end of file at {} (needed {len} bytes)",
-                self.pos
+                "unexpected end of file: needed {len} bytes at offset {} but only {} remain",
+                self.pos,
+                self.remaining()
             )));
-        }
+        };
         let start = self.pos;
-        self.pos += len;
-        Ok(&self.data[start..start + len])
+        self.pos = end;
+        Ok(&self.data[start..end])
     }
 
     pub fn read_uleb128(&mut self) -> Result<u64> {
@@ -158,7 +174,12 @@ impl<'a> ByteReader<'a> {
         if len == 0 {
             return Ok(String::new());
         }
-        let bytes = self.read_exact(len)?;
+        let bytes = self.read_exact(len).map_err(|_| {
+            Error::Parse(format!(
+                "length-prefixed string claims {len} bytes but only {} remain (likely a mis-aligned section)",
+                self.remaining()
+            ))
+        })?;
         Ok(String::from_utf8_lossy(bytes).into_owned())
     }
 }

--- a/crates/hbc-decomp/src/ir/builder/ir_builder.rs
+++ b/crates/hbc-decomp/src/ir/builder/ir_builder.rs
@@ -105,7 +105,11 @@ impl<'a> IRBuilder<'a> {
 
             if self.options.include_offsets {
                 if self.options.absolute_offsets {
-                    let abs_offset = self.file.instruction_offset + func_bytecode_offset + inst.offset;
+                    let abs_offset = self
+                        .file
+                        .instruction_offset
+                        .wrapping_add(func_bytecode_offset)
+                        .wrapping_add(inst.offset);
                     current_stmts.push(Statement::Comment(format!("@{abs_offset:08x}")));
                 } else {
                     current_stmts.push(Statement::Comment(format!("@{:04x}", inst.offset)));

--- a/crates/hbc-decomp/src/ir/builder/jump_analysis.rs
+++ b/crates/hbc-decomp/src/ir/builder/jump_analysis.rs
@@ -31,7 +31,7 @@ pub fn find_block_starts_with_handlers(
         // Instructions that end a block - next instruction starts a new block
         if matches!(name, "Ret" | "Throw" | "Jmp" | "JmpLong") {
             // The instruction after this one starts a new block (if it exists)
-            let next_offset = inst.offset + inst.length;
+            let next_offset = inst.offset.wrapping_add(inst.length);
             targets.insert(next_offset);
         }
 
@@ -40,7 +40,7 @@ pub fn find_block_starts_with_handlers(
             for operand in &inst.operands {
                 if matches!(operand.ty, OperandType::Addr8 | OperandType::Addr32) {
                     if let Some(rel) = operand.value.as_i32() {
-                        let target = inst.offset as i32 + rel;
+                        let target = (inst.offset as i32).wrapping_add(rel);
                         if target >= 0 {
                             targets.insert(target as u32);
                         }
@@ -49,7 +49,7 @@ pub fn find_block_starts_with_handlers(
             }
             // Conditional jumps also have a fall-through to next instruction
             if is_conditional_jump(name) {
-                targets.insert(inst.offset + inst.length);
+                targets.insert(inst.offset.wrapping_add(inst.length));
             }
         }
 
@@ -69,12 +69,12 @@ pub fn find_block_starts_with_handlers(
                     max_op.value.as_u32(),
                 ) {
                     // Default target
-                    let default_target = (inst.offset as i32 + default_offset) as u32;
+                    let default_target = (inst.offset as i32).wrapping_add(default_offset) as u32;
                     targets.insert(default_target);
 
                     // Read jump table: jmpTableIdx is a byte offset from the SwitchImm instruction
-                    let table_start_local = inst.offset as usize + jmp_table_idx as usize;
-                    let table_start_global = table_start_local + func_bytecode_offset as usize;
+                    let table_start_local = (inst.offset as usize).saturating_add(jmp_table_idx as usize);
+                    let table_start_global = table_start_local.saturating_add(func_bytecode_offset as usize);
                     // Guard against maxVal < minVal (would underflow) in malformed bytecode.
                     let count = max_val.checked_sub(min_val).map_or(0, |span| span as usize + 1);
 
@@ -86,7 +86,7 @@ pub fn find_block_starts_with_handlers(
                         let mut reader = ByteReader::new(&file.instructions[table_start_global..]);
                         for _ in 0..count {
                             if let Ok(rel_offset) = reader.read_i32() {
-                                let target = (inst.offset as i32 + rel_offset) as u32;
+                                let target = (inst.offset as i32).wrapping_add(rel_offset) as u32;
                                 targets.insert(target);
                             }
                         }
@@ -108,11 +108,11 @@ pub fn find_block_starts_with_handlers(
                     num_cases_op.value.as_u32(),
                     default_op.value.as_i32(),
                 ) {
-                    let default_target = (inst.offset as i32 + default_offset) as u32;
+                    let default_target = (inst.offset as i32).wrapping_add(default_offset) as u32;
                     targets.insert(default_target);
 
-                    let table_start_local = inst.offset as usize + jmp_table_idx as usize;
-                    let table_start_global = table_start_local + func_bytecode_offset as usize;
+                    let table_start_local = (inst.offset as usize).saturating_add(jmp_table_idx as usize);
+                    let table_start_global = table_start_local.saturating_add(func_bytecode_offset as usize);
                     let count = num_cases as usize;
 
                     if table_start_global + count * 4 <= file.instructions.len() {
@@ -120,7 +120,7 @@ pub fn find_block_starts_with_handlers(
                         let mut reader = ByteReader::new(&file.instructions[table_start_global..]);
                         for _ in 0..count {
                             if let Ok(rel_offset) = reader.read_i32() {
-                                let target = (inst.offset as i32 + rel_offset) as u32;
+                                let target = (inst.offset as i32).wrapping_add(rel_offset) as u32;
                                 targets.insert(target);
                             }
                         }

--- a/crates/hbc-decomp/src/ir/builder/jump_analysis.rs
+++ b/crates/hbc-decomp/src/ir/builder/jump_analysis.rs
@@ -75,9 +75,13 @@ pub fn find_block_starts_with_handlers(
                     // Read jump table: jmpTableIdx is a byte offset from the SwitchImm instruction
                     let table_start_local = inst.offset as usize + jmp_table_idx as usize;
                     let table_start_global = table_start_local + func_bytecode_offset as usize;
-                    let count = (max_val - min_val + 1) as usize;
+                    // Guard against maxVal < minVal (would underflow) in malformed bytecode.
+                    let count = max_val.checked_sub(min_val).map_or(0, |span| span as usize + 1);
 
-                    if table_start_global + count * 4 <= file.instructions.len() {
+                    if count > 0
+                        && table_start_global.saturating_add(count.saturating_mul(4))
+                            <= file.instructions.len()
+                    {
                         use crate::io::ByteReader;
                         let mut reader = ByteReader::new(&file.instructions[table_start_global..]);
                         for _ in 0..count {

--- a/crates/hbc-decomp/src/ir/builder/opcodes_call.rs
+++ b/crates/hbc-decomp/src/ir/builder/opcodes_call.rs
@@ -4,6 +4,11 @@ use super::opcodes_load::{get_reg, reg_expr};
 use crate::ir::{AssignTarget, Expression, Statement, Value};
 use crate::{BytecodeFile, Instruction};
 
+/// Upper bound for a call's argument count when pre-allocating. `arg_count`
+/// comes from a u32 operand; a corrupt value would otherwise abort the process
+/// in `Vec::with_capacity`. Real call sites have far fewer arguments than this.
+const MAX_CALL_ARGS: usize = 1 << 16;
+
 // Handle Call1, Call2, Call3, Call4 opcodes (fixed argument count).
 pub fn handle_call_fixed(name: &str, inst: &Instruction) -> Option<Statement> {
     let dst = get_reg(&inst.operands, 0)?;
@@ -40,8 +45,8 @@ pub fn handle_call(inst: &Instruction) -> Option<Statement> {
     let callee = reg_expr(&inst.operands, 1)?;
     let arg_count = inst.operands.get(2)?.value.as_u32()? as usize;
 
-    // Arguments are in registers dst-arg_count to dst-1
-    let mut arguments = Vec::with_capacity(arg_count);
+    // Arguments are in registers dst-arg_count to dst-1.
+    let mut arguments = Vec::with_capacity(arg_count.min(MAX_CALL_ARGS));
     if arg_count > 0 && dst >= arg_count as u32 {
         let first_arg = dst - arg_count as u32;
         for i in 0..arg_count {
@@ -64,8 +69,8 @@ pub fn handle_construct(inst: &Instruction) -> Option<Statement> {
     let callee = reg_expr(&inst.operands, 1)?;
     let arg_count = inst.operands.get(2)?.value.as_u32()? as usize;
 
-    // Arguments are in registers dst-arg_count to dst-1
-    let mut arguments = Vec::with_capacity(arg_count);
+    // Arguments are in registers dst-arg_count to dst-1.
+    let mut arguments = Vec::with_capacity(arg_count.min(MAX_CALL_ARGS));
     if arg_count > 0 && dst >= arg_count as u32 {
         let first_arg = dst - arg_count as u32;
         for i in 0..arg_count {
@@ -192,8 +197,8 @@ pub fn handle_call_builtin(inst: &Instruction) -> Option<Statement> {
     let builtin_idx = inst.operands.get(1)?.value.as_u32()?;
     let arg_count = inst.operands.get(2)?.value.as_u32()? as usize;
 
-    // Arguments are in registers dst-arg_count to dst-1
-    let mut arguments = Vec::with_capacity(arg_count);
+    // Arguments are in registers dst-arg_count to dst-1.
+    let mut arguments = Vec::with_capacity(arg_count.min(MAX_CALL_ARGS));
     if arg_count > 0 && dst >= arg_count as u32 {
         let first_arg = dst - arg_count as u32;
         for i in 0..arg_count {

--- a/crates/hbc-decomp/src/ir/builder/opcodes_flow.rs
+++ b/crates/hbc-decomp/src/ir/builder/opcodes_flow.rs
@@ -48,7 +48,7 @@ pub fn handle_jmp_cond(
 ) -> Option<FlowResult> {
     let target = get_jump_target(inst, format)?;
     let cond = reg_expr(&inst.operands, 1)?;
-    let fallthrough = inst.offset + inst.length;
+    let fallthrough = inst.offset.wrapping_add(inst.length);
 
     let condition = if name.contains("False") {
         Expression::unary(crate::ir::UnaryOp::Not, cond)
@@ -73,7 +73,7 @@ pub fn handle_jmp_comparison(
     let target = get_jump_target(inst, format)?;
     let left = reg_expr(&inst.operands, 1)?;
     let right = reg_expr(&inst.operands, 2)?;
-    let fallthrough = inst.offset + inst.length;
+    let fallthrough = inst.offset.wrapping_add(inst.length);
 
     // Strip "Long" suffix for matching
     let base_name = name.trim_end_matches("Long");
@@ -125,7 +125,7 @@ pub fn handle_jmp_typeof_is(
 ) -> Option<FlowResult> {
     let target = get_jump_target(inst, format)?;
     let src = reg_expr(&inst.operands, 1)?;
-    let fallthrough = inst.offset + inst.length;
+    let fallthrough = inst.offset.wrapping_add(inst.length);
 
     let type_idx = inst.operands.get(2)?.value.as_u32()?;
     let type_str = file
@@ -155,7 +155,7 @@ pub fn handle_jmp_builtin_is(
     let target = get_jump_target(inst, format)?;
     let type_id = inst.operands.get(1)?.value.as_u32()?;
     let src = reg_expr(&inst.operands, 2)?;
-    let fallthrough = inst.offset + inst.length;
+    let fallthrough = inst.offset.wrapping_add(inst.length);
 
     let type_str = typeof_id_to_string(type_id).to_string();
 
@@ -224,7 +224,7 @@ pub fn handle_jmp_undefined(
 ) -> Option<FlowResult> {
     let target = get_jump_target(inst, format)?;
     let val = reg_expr(&inst.operands, 1)?;
-    let fallthrough = inst.offset + inst.length;
+    let fallthrough = inst.offset.wrapping_add(inst.length);
 
     let condition = Expression::binary(
         BinaryOp::StrictEq,
@@ -268,7 +268,7 @@ pub(super) fn get_jump_target(inst: &Instruction, format: &BytecodeFormat) -> Op
     for operand in &inst.operands {
         if matches!(operand.ty, OperandType::Addr8 | OperandType::Addr32) {
             if let Some(rel) = operand.value.as_i32() {
-                let target = inst.offset as i32 + rel;
+                let target = (inst.offset as i32).wrapping_add(rel);
                 if target >= 0 {
                     return Some(target as u32);
                 }

--- a/crates/hbc-decomp/src/ir/builder/opcodes_generator.rs
+++ b/crates/hbc-decomp/src/ir/builder/opcodes_generator.rs
@@ -80,7 +80,7 @@ pub fn handle_save_generator(inst: &crate::Instruction, _format: &crate::Bytecod
         _ => return None,
     };
 
-    let resume_addr = (inst.offset as i32 + resume_offset) as u32;
+    let resume_addr = (inst.offset as i32).wrapping_add(resume_offset) as u32;
 
     // SaveGenerator creates a yield point
     // We mark this with a special statement that will be transformed later

--- a/crates/hbc-decomp/src/ir/builder/opcodes_switch.rs
+++ b/crates/hbc-decomp/src/ir/builder/opcodes_switch.rs
@@ -19,10 +19,10 @@ pub fn handle_switch_imm(
     let min_val = inst.operands.get(3)?.value.as_u32()?;
     let max_val = inst.operands.get(4)?.value.as_u32()?;
 
-    let default_target = (inst.offset as i32 + default_offset) as u32;
+    let default_target = (inst.offset as i32).wrapping_add(default_offset) as u32;
 
-    let table_start_local = inst.offset as usize + jmp_table_idx as usize;
-    let table_start_global = table_start_local + func_bytecode_offset as usize;
+    let table_start_local = (inst.offset as usize).saturating_add(jmp_table_idx as usize);
+    let table_start_global = table_start_local.saturating_add(func_bytecode_offset as usize);
 
     // Malformed bytecode can have maxVal < minVal; a plain `max_val - min_val`
     // underflows (panics in debug, wraps to ~4 billion in release and then
@@ -52,8 +52,8 @@ pub fn handle_switch_imm(
 
     for i in 0..count {
         if let Ok(rel_offset) = reader.read_i32() {
-            let target = (inst.offset as i32 + rel_offset) as u32;
-            let case_val = min_val + i as u32;
+            let target = (inst.offset as i32).wrapping_add(rel_offset) as u32;
+            let case_val = min_val.wrapping_add(i as u32);
             cases.push((
                 Expression::Value(crate::ir::Value::Constant(crate::ir::Constant::Integer(case_val as i32))),
                 target,
@@ -82,15 +82,15 @@ pub fn handle_string_switch_imm(
     let default_offset = inst.operands.get(3)?.value.as_i32()?;
     let string_table_offset = inst.operands.get(4)?.value.as_u32()?;
 
-    let default_target = (inst.offset as i32 + default_offset) as u32;
+    let default_target = (inst.offset as i32).wrapping_add(default_offset) as u32;
 
-    let table_start_local = inst.offset as usize + jmp_table_idx as usize;
-    let table_start_global = table_start_local + func_bytecode_offset as usize;
+    let table_start_local = (inst.offset as usize).saturating_add(jmp_table_idx as usize);
+    let table_start_global = table_start_local.saturating_add(func_bytecode_offset as usize);
 
     let count = num_cases as usize;
-    let mut cases = Vec::with_capacity(count);
 
-    if table_start_global + count * 4 > file.instructions.len() {
+    // Bounds-check before allocating so a huge numCases can't capacity-overflow.
+    if table_start_global.saturating_add(count.saturating_mul(4)) > file.instructions.len() {
         return Some(FlowResult::Statement(Statement::Comment(format!(
             "StringSwitchImm: jump table out of bounds (start={}, count={}, len={})",
             table_start_global,
@@ -99,16 +99,18 @@ pub fn handle_string_switch_imm(
         ))));
     }
 
+    let mut cases = Vec::with_capacity(count);
+
     use crate::io::ByteReader;
     let mut reader = ByteReader::new(&file.instructions[table_start_global..]);
 
     for i in 0..count {
         if let Ok(rel_offset) = reader.read_i32() {
-            let target = (inst.offset as i32 + rel_offset) as u32;
+            let target = (inst.offset as i32).wrapping_add(rel_offset) as u32;
             let case_str = file
-                .string_at(string_table_offset + i as u32)
+                .string_at(string_table_offset.wrapping_add(i as u32))
                 .map(|e| e.value.clone())
-                .unwrap_or_else(|| format!("string{}", string_table_offset + i as u32));
+                .unwrap_or_else(|| format!("string{}", string_table_offset.wrapping_add(i as u32)));
             cases.push((
                 Expression::Value(crate::ir::Value::Constant(crate::ir::Constant::String(case_str))),
                 target,

--- a/crates/hbc-decomp/src/ir/builder/opcodes_switch.rs
+++ b/crates/hbc-decomp/src/ir/builder/opcodes_switch.rs
@@ -24,11 +24,19 @@ pub fn handle_switch_imm(
     let table_start_local = inst.offset as usize + jmp_table_idx as usize;
     let table_start_global = table_start_local + func_bytecode_offset as usize;
 
-    let count = (max_val - min_val + 1) as usize;
-    let mut cases = Vec::with_capacity(count);
+    // Malformed bytecode can have maxVal < minVal; a plain `max_val - min_val`
+    // underflows (panics in debug, wraps to ~4 billion in release and then
+    // blows up Vec::with_capacity). Reject the bad range instead.
+    let Some(span) = max_val.checked_sub(min_val) else {
+        return Some(FlowResult::Statement(Statement::Comment(format!(
+            "SwitchImm: invalid range (maxVal {max_val} < minVal {min_val})"
+        ))));
+    };
+    let count = span as usize + 1;
 
-    // Ensure we don't read past end of file
-    if table_start_global + count * 4 > file.instructions.len() {
+    // Bounds-check BEFORE allocating so a huge (or corrupt) table can't trigger
+    // a capacity-overflow abort in Vec::with_capacity.
+    if table_start_global.saturating_add(count.saturating_mul(4)) > file.instructions.len() {
         return Some(FlowResult::Statement(Statement::Comment(format!(
             "SwitchImm: jump table out of bounds (start={}, count={}, len={})",
             table_start_global,
@@ -36,6 +44,8 @@ pub fn handle_switch_imm(
             file.instructions.len()
         ))));
     }
+
+    let mut cases = Vec::with_capacity(count);
 
     use crate::io::ByteReader;
     let mut reader = ByteReader::new(&file.instructions[table_start_global..]);

--- a/crates/hbc-decomp/src/lib.rs
+++ b/crates/hbc-decomp/src/lib.rs
@@ -29,6 +29,23 @@
 // Suppress collapsible_match/collapsible_if: fixing these requires unstable let-chains (RFC #53667)
 #![allow(clippy::collapsible_match, clippy::collapsible_if)]
 
+/// Configure the global Rayon thread pool with a large worker stack.
+///
+/// Decompilation recurses deeply (CFG structure recovery, closure resolution)
+/// and runs across Rayon workers. Rayon's default worker stack (~2 MB) overflows
+/// and aborts the process on large real-world bundles (e.g. a Metro `global`
+/// function). Call this once at program start — before any decompilation — so
+/// every worker gets enough stack. It is idempotent and best-effort: if the pool
+/// is already initialized it does nothing.
+pub fn configure_thread_pool() {
+    static INIT: std::sync::Once = std::sync::Once::new();
+    INIT.call_once(|| {
+        let _ = rayon::ThreadPoolBuilder::new()
+            .stack_size(64 * 1024 * 1024)
+            .build_global();
+    });
+}
+
 pub mod debug;
 pub mod disasm;
 pub mod error;

--- a/crates/hbc-decomp/src/pipeline/context/mod.rs
+++ b/crates/hbc-decomp/src/pipeline/context/mod.rs
@@ -39,7 +39,7 @@ impl PipelineContext {
 
     // Run the full analysis pipeline with user-provided options.
     pub fn build_with_options(file: &BytecodeFile, format: &BytecodeFormat, user_options: &DecompileOptionsV2) -> Result<Self> {
-        Self::init_rayon();
+        crate::configure_thread_pool();
 
         let total_start = std::time::Instant::now();
         let options = DecompileOptionsV2 {
@@ -88,14 +88,6 @@ impl PipelineContext {
         Ok(ctx)
     }
 
-    fn init_rayon() {
-        static INIT_RAYON: std::sync::Once = std::sync::Once::new();
-        INIT_RAYON.call_once(|| {
-            let _ = rayon::ThreadPoolBuilder::new()
-                .stack_size(8 * 1024 * 1024)
-                .build_global();
-        });
-    }
 
     // Phase 1b: Detect Metro modules by scanning the global function with minimal IR.
     fn build_metro_registry(file: &BytecodeFile, format: &BytecodeFormat) -> crate::analysis::MetroRegistry {

--- a/crates/hbc-decomp/src/pipeline/context/mod.rs
+++ b/crates/hbc-decomp/src/pipeline/context/mod.rs
@@ -51,7 +51,7 @@ impl PipelineContext {
         // STAGE W1: Closure Context Build
         let t = std::time::Instant::now();
         let mut closure_ctx = Some(build_closure_context_from_file(file, format)?);
-        eprintln!("[pipeline] closure context: {:.2?}", t.elapsed());
+        log::debug!("[pipeline] closure context: {:.2?}", t.elapsed());
 
         // STAGE W2: Metro Detection
         let mut registry = Self::build_metro_registry(file, format);
@@ -80,10 +80,10 @@ impl PipelineContext {
 
         let t = std::time::Instant::now();
         ctx.build_all_inline_bodies(file);
-        eprintln!("[pipeline] inline body rendering: {:.2?} ({} of {} functions)", t.elapsed(), ctx.inline_bodies.len(), file.header.function_count);
+        log::debug!("[pipeline] inline body rendering: {:.2?} ({} of {} functions)", t.elapsed(), ctx.inline_bodies.len(), file.header.function_count);
 
-        eprintln!("[pipeline] exception handlers: {} functions with try/catch", file.exception_handlers.len());
-        eprintln!("[pipeline] TOTAL: {:.2?}", total_start.elapsed());
+        log::debug!("[pipeline] exception handlers: {} functions with try/catch", file.exception_handlers.len());
+        log::debug!("[pipeline] TOTAL: {:.2?}", total_start.elapsed());
 
         Ok(ctx)
     }
@@ -102,7 +102,7 @@ impl PipelineContext {
         if let Ok(stmts) = generate_ir(file, format, global_idx, &raw_options, None, false) {
             registry.analyze_statements(&stmts);
         }
-        eprintln!("[pipeline] metro detection: {:.2?} ({} modules)", t.elapsed(), registry.modules.len());
+        log::debug!("[pipeline] metro detection: {:.2?} ({} modules)", t.elapsed(), registry.modules.len());
         registry
     }
 
@@ -122,7 +122,7 @@ impl PipelineContext {
                 .into_par_iter()
                 .map(|i| {
                     let stmts = generate_ir(file, format, i, options, ctx_ref, false)
-                        .map_err(|e| eprintln!("[pipeline] IR gen failed for func {i}: {e}"))
+                        .map_err(|e| log::debug!("[pipeline] IR gen failed for func {i}: {e}"))
                         .ok()?;
                     let named = super::apply_register_naming(stmts, file, i);
                     let semantic = transforms::infer_variable_names(named);
@@ -132,7 +132,7 @@ impl PipelineContext {
                 })
                 .collect()
         };
-        eprintln!("[pipeline] optimized IR generation (parallel): {:.2?}", t.elapsed());
+        log::debug!("[pipeline] optimized IR generation (parallel): {:.2?}", t.elapsed());
 
         let t = std::time::Instant::now();
         let mut all_ir = BTreeMap::new();
@@ -146,7 +146,7 @@ impl PipelineContext {
         if let Some(ctx) = closure_ctx.as_mut() {
             ctx.propagate_async_to_generators();
         }
-        eprintln!("[pipeline] closure analyze + insert: {:.2?}", t.elapsed());
+        log::debug!("[pipeline] closure analyze + insert: {:.2?}", t.elapsed());
         all_ir
     }
 
@@ -160,14 +160,14 @@ impl PipelineContext {
         // STAGE W5: Module Name Propagation
         let t = std::time::Instant::now();
         crate::analysis::metro::propagate_module_names(all_ir, registry, closure_ctx);
-        eprintln!("[pipeline] module name propagation: {:.2?}", t.elapsed());
+        log::debug!("[pipeline] module name propagation: {:.2?}", t.elapsed());
 
         // STAGE W6: Closure Resolution (first pass)
         let t = std::time::Instant::now();
         if let Some(ctx) = closure_ctx.as_ref() {
             Self::resolve_all_closures(all_ir, ctx);
         }
-        eprintln!("[pipeline] closure resolution: {:.2?}", t.elapsed());
+        log::debug!("[pipeline] closure resolution: {:.2?}", t.elapsed());
 
         // STAGE W7: Metro Export Analysis
         let t = std::time::Instant::now();
@@ -178,13 +178,13 @@ impl PipelineContext {
                 crate::analysis::metro::exports::ExportAnalyzer::analyze(module, all_ir);
             }
         }
-        eprintln!("[pipeline] metro export analysis: {:.2?}", t.elapsed());
+        log::debug!("[pipeline] metro export analysis: {:.2?}", t.elapsed());
 
         // STAGE W8: Inter-Procedural Analysis (IPA)
         let t = std::time::Instant::now();
         let func_name_index = build_function_name_index(file);
         let global_analysis = crate::analysis::run_ipa(all_ir, registry, &func_name_index);
-        eprintln!("[pipeline] IPA: {:.2?}", t.elapsed());
+        log::debug!("[pipeline] IPA: {:.2?}", t.elapsed());
 
         // STAGE W9: IPA Closure Re-resolve
         let t = std::time::Instant::now();
@@ -192,7 +192,7 @@ impl PipelineContext {
             ctx.update_with_ipa_names(&global_analysis.param_names);
             Self::resolve_all_closures(all_ir, ctx);
         }
-        eprintln!("[pipeline] IPA closure re-resolve: {:.2?}", t.elapsed());
+        log::debug!("[pipeline] IPA closure re-resolve: {:.2?}", t.elapsed());
 
         // STAGE W10: Closure Property Naming (cross-function)
         let t = std::time::Instant::now();
@@ -209,12 +209,12 @@ impl PipelineContext {
             }
             count
         };
-        eprintln!("[pipeline] closure property naming: {:.2?} ({closure_renames} variables renamed)", t.elapsed());
+        log::debug!("[pipeline] closure property naming: {:.2?} ({closure_renames} variables renamed)", t.elapsed());
 
         // STAGE W11: Definition-site closure naming
         let def_renames = transforms::rename_closures_from_definitions(all_ir);
         if def_renames > 0 {
-            eprintln!("[pipeline] closure definition naming: {def_renames} variables renamed");
+            log::debug!("[pipeline] closure definition naming: {def_renames} variables renamed");
         }
 
         global_analysis
@@ -238,7 +238,7 @@ impl PipelineContext {
             let old = std::mem::take(stmts);
             *stmts = transforms::inline_named_variables(old);
         }
-        eprintln!("[pipeline] variable inlining: {:.2?}", t.elapsed());
+        log::debug!("[pipeline] variable inlining: {:.2?}", t.elapsed());
 
         // STAGE W14: Detect async generator patterns (yield → await)
         if let Some(ctx) = closure_ctx.as_mut() {
@@ -253,7 +253,7 @@ impl PipelineContext {
                         *stmts = convert_yields_to_awaits(old);
                     }
                 }
-                eprintln!("[pipeline] async detection: {} functions converted yield→await", async_gen_ids.len());
+                log::debug!("[pipeline] async detection: {} functions converted yield→await", async_gen_ids.len());
             }
         }
 
@@ -261,7 +261,7 @@ impl PipelineContext {
         if let Some(ctx) = closure_ctx.as_mut() {
             let unwrapped = async_detection::unwrap_async_wrappers(all_ir, ctx, &mut global_analysis.param_names, file);
             if unwrapped > 0 {
-                eprintln!("[pipeline] async wrapper unwrap: {unwrapped} functions unwrapped");
+                log::debug!("[pipeline] async wrapper unwrap: {unwrapped} functions unwrapped");
             }
         }
 

--- a/crates/hbc-decomp/src/transforms/class_patterns/analyzer/emit.rs
+++ b/crates/hbc-decomp/src/transforms/class_patterns/analyzer/emit.rs
@@ -33,7 +33,7 @@ impl<'a> ClassAnalyzer<'a> {
     pub(super) fn fetch_body(&self, expr: &Expression) -> Option<Vec<Statement>> {
         if let Expression::Function { id, .. } = expr {
             crate::generate_ir(self.file, self.format, id.0, self.options, self.closure_ctx, true)
-                .map_err(|e| eprintln!("[class_patterns] IR gen failed for func {}: {e}", id.0))
+                .map_err(|e| log::debug!("[class_patterns] IR gen failed for func {}: {e}", id.0))
                 .ok()
         } else {
             None


### PR DESCRIPTION
Fixes #4

On v96 bundles, info, bin-diff and disasm aborted with capacity overflow: the debug-info header has seven u32 fields but the reader only read three, mistaking counts for offsets and asking for a ~4-billion-element allocation. DebugInfo::parse now reads the full header with bounds checks (and recovers real v96 variable names)