### PR TITLE
Add content search with syntax highlighting preserved

### DIFF
--- a/crates/hbc-decomp-cli/src/tui/app.rs
+++ b/crates/hbc-decomp-cli/src/tui/app.rs
@@ -9,6 +9,7 @@ use hbc_decomp::{BytecodeFile, BytecodeFormat, PipelineContext};
 
 use super::debug_log;
 use super::gitdiff::{self, GitDiffJob, GitMsg, GitRow};
+use super::disasm_or_log;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ViewMode {
@@ -130,6 +131,12 @@ pub struct App {
     pub list_state: ListState,
     // Inner area of the function list (set during draw), for click-to-select.
     pub list_inner: Rect,
+
+    // Content search state (search within selected function's content)
+    pub content_search: String,
+    pub is_content_searching: bool,
+    pub content_search_matches: Vec<(usize, usize)>, // (line_idx, char_idx) pairs
+    pub content_search_index: usize, // Current match index (0-based)
 
     // Full pipeline context (IPA, Metro, naming) — built in background
     pub pipeline_ctx: Option<Arc<PipelineContext>>,
@@ -260,6 +267,10 @@ impl App {
             tick: 0,
             list_state: ListState::default().with_selected(Some(0)),
             list_inner: Rect::default(),
+            content_search: String::new(),
+            is_content_searching: false,
+            content_search_matches: Vec::new(),
+            content_search_index: 0,
             pipeline_ctx: None,
             pipeline_rx: None,
             pipeline_building: false,
@@ -629,6 +640,86 @@ impl App {
             self.list_state.select(Some(0));
         }
         self.scroll = 0;
+    }
+
+    pub fn update_content_search(&mut self) {
+        self.content_search_matches.clear();
+        self.content_search_index = 0;
+
+        if self.content_search.is_empty() {
+            return;
+        }
+
+        let content_text = self.get_content_text();
+        let query = self.content_search.to_lowercase();
+
+        for (line_idx, line) in content_text.lines().enumerate() {
+            let line_lower = line.to_lowercase();
+            let mut char_idx = 0;
+            while let Some(pos) = line_lower[char_idx..].find(&query) {
+                self.content_search_matches
+                    .push((line_idx, char_idx + pos));
+                char_idx += pos + 1;
+            }
+        }
+
+        if !self.content_search_matches.is_empty() {
+            self.content_search_jump_to(0);
+        }
+    }
+
+    pub fn content_search_next(&mut self) {
+        if self.content_search_matches.is_empty() {
+            return;
+        }
+        let next = (self.content_search_index + 1) % self.content_search_matches.len();
+        self.content_search_jump_to(next);
+    }
+
+    pub fn content_search_prev(&mut self) {
+        if self.content_search_matches.is_empty() {
+            return;
+        }
+        let prev = if self.content_search_index == 0 {
+            self.content_search_matches.len() - 1
+        } else {
+            self.content_search_index - 1
+        };
+        self.content_search_jump_to(prev);
+    }
+
+    fn content_search_jump_to(&mut self, match_idx: usize) {
+        self.content_search_index = match_idx;
+        if let Some(&(line_idx, _)) = self.content_search_matches.get(match_idx) {
+            self.scroll = line_idx as u32;
+        }
+    }
+
+    fn get_content_text(&mut self) -> String {
+        match self.view {
+            ViewMode::Disasm => {
+                if let Some(id) = self.selected_function_id() {
+                    disasm_or_log(&self.file, &self.format, id)
+                } else {
+                    String::new()
+                }
+            }
+            ViewMode::Decompile => self.decompile_content(),
+            ViewMode::Info => self.format_info_wrapper(),
+            ViewMode::Diff => {
+                let (left, _) = self.content();
+                left.lines
+                    .iter()
+                    .map(|line| {
+                        line.spans
+                            .iter()
+                            .map(|span| span.content.as_ref())
+                            .collect::<String>()
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
     }
 
     // Deep search: also scans string literals in bytecode (called on Enter).

--- a/crates/hbc-decomp-cli/src/tui/events.rs
+++ b/crates/hbc-decomp-cli/src/tui/events.rs
@@ -83,6 +83,37 @@ fn handle_key(app: &mut App, key: KeyEvent) -> bool {
         return false;
     }
 
+    // Content search mode: search within the selected function's content
+    if app.is_content_searching {
+        match key.code {
+            KeyCode::Esc => {
+                app.is_content_searching = false;
+                app.content_search.clear();
+                app.content_search_matches.clear();
+                app.content_search_index = 0;
+            }
+            KeyCode::Enter => {
+                app.content_search_next();
+            }
+            KeyCode::Down => {
+                app.content_search_next();
+            }
+            KeyCode::Up => {
+                app.content_search_prev();
+            }
+            KeyCode::Backspace => {
+                app.content_search.pop();
+                app.update_content_search();
+            }
+            KeyCode::Char(c) => {
+                app.content_search.push(c);
+                app.update_content_search();
+            }
+            _ => {}
+        }
+        return false;
+    }
+
     // Full-program git diff is a separate full-screen mode with its own keys.
     if app.git_diff {
         return handle_git_key(app, key);
@@ -92,6 +123,9 @@ fn handle_key(app: &mut App, key: KeyEvent) -> bool {
     match key.code {
         KeyCode::Char('/') => {
             app.is_searching = true;
+        }
+        KeyCode::Char('s') => {
+            app.is_content_searching = true;
         }
         KeyCode::Char('d') => {
             app.show_diff_colors = !app.show_diff_colors;

--- a/crates/hbc-decomp-cli/src/tui/ui.rs
+++ b/crates/hbc-decomp-cli/src/tui/ui.rs
@@ -89,6 +89,8 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App) {
             Span::styled(" nav ", Style::default().fg(Color::DarkGray)),
             Span::styled("/", Style::default().fg(Color::White)),
             Span::styled(" search ", Style::default().fg(Color::DarkGray)),
+            Span::styled("s", Style::default().fg(Color::White)),
+            Span::styled(" find ", Style::default().fg(Color::DarkGray)),
             Span::styled("Tab", Style::default().fg(Color::White)),
             Span::styled(" view ", Style::default().fg(Color::DarkGray)),
             Span::styled("PgUp/Dn", Style::default().fg(Color::White)),
@@ -117,6 +119,8 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App) {
             Span::styled(" navigate ", Style::default().fg(Color::DarkGray)),
             Span::styled("/", Style::default().fg(Color::White)),
             Span::styled(" search ", Style::default().fg(Color::DarkGray)),
+            Span::styled("s", Style::default().fg(Color::White)),
+            Span::styled(" find ", Style::default().fg(Color::DarkGray)),
             Span::styled("Tab", Style::default().fg(Color::White)),
             Span::styled(" view ", Style::default().fg(Color::DarkGray)),
             Span::styled("PgUp/Dn", Style::default().fg(Color::White)),
@@ -127,6 +131,37 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App) {
     };
     let footer = Paragraph::new(footer_line);
     frame.render_widget(footer, layout[2]);
+
+    if app.is_content_searching {
+        let popup = centered_rect(54, 3, frame.area());
+        frame.render_widget(Clear, popup);
+        let count = if app.content_search.is_empty() {
+            String::new()
+        } else if app.content_search_matches.is_empty() {
+            "   no match".to_string()
+        } else {
+            format!(
+                "   [{}/{}]",
+                app.content_search_index + 1,
+                app.content_search_matches.len()
+            )
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("s ", Style::default().fg(Color::Cyan)),
+                Span::raw(app.content_search.clone()),
+                Span::styled("_", Style::default().fg(Color::Cyan)),
+                Span::styled(count, Style::default().fg(Color::Yellow)),
+            ]))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Double)
+                    .title(" Search in content — \u{2193}/Enter: next  \u{2191}: prev  Esc: close "),
+            ),
+            popup,
+        );
+    }
 }
 
 fn draw_function_list(frame: &mut Frame, app: &mut App, area: Rect) {
@@ -213,7 +248,23 @@ fn draw_content_pane(
         app.scroll = max_scroll;
     }
 
-    let paragraph = Paragraph::new(content)
+    let q = if !app.content_search.is_empty() {
+        Some(app.content_search.to_lowercase())
+    } else {
+        None
+    };
+
+    let highlighted: Vec<Line<'static>> = if q.is_some() {
+        content
+            .lines
+            .into_iter()
+            .map(|line| highlight_line_with_search(line, q.as_deref()))
+            .collect()
+    } else {
+        content.lines
+    };
+
+    let paragraph = Paragraph::new(highlighted)
         .block(
             Block::default()
                 .borders(Borders::ALL)
@@ -253,6 +304,43 @@ fn highlight_spans(text: &str, base: Style, query: Option<&str>) -> Vec<Span<'st
         }
         _ => vec![Span::styled(text.to_string(), base)],
     }
+}
+
+fn highlight_line_with_search(line: Line<'static>, query: Option<&str>) -> Line<'static> {
+    let q = match query {
+        Some(q) if !q.is_empty() => q,
+        _ => return line,
+    };
+
+    let hl = Style::default().fg(Color::Black).bg(Color::Yellow);
+    let mut result_spans = Vec::new();
+
+    for span in line.spans {
+        let text = &span.content;
+        let base_style = span.style;
+        let lower = text.to_lowercase();
+
+        if !lower.contains(q) {
+            result_spans.push(span);
+            continue;
+        }
+
+        let mut i = 0;
+        while let Some(pos) = lower[i..].find(q) {
+            let s = i + pos;
+            let e = s + q.len();
+            if s > i {
+                result_spans.push(Span::styled(text[i..s].to_string(), base_style));
+            }
+            result_spans.push(Span::styled(text[s..e].to_string(), hl));
+            i = e;
+        }
+        if i < text.len() {
+            result_spans.push(Span::styled(text[i..].to_string(), base_style));
+        }
+    }
+
+    Line::from(result_spans)
 }
 
 /// One side of a diff row: git-style sign (`+`/`-`/space), a line-number


### PR DESCRIPTION
## Summary
Add `s` key to search for strings within the selected function's content. Matches are highlighted with yellow background while preserving syntax highlighting colors.

## Changes

### New Features
- Press `s` to enter content search mode
- Type to search within disassembly/decompiled/info views
- `Enter`/`Down` navigates to next match
- `Up` navigates to previous match
- `Esc` exits search mode
- Match count shown in popup `[1/5]`
- Content scrolls to show matched line

### Files Modified
- `crates/hbc-decomp-cli/src/tui/app.rs` - Added content search state and methods
- `crates/hbc-decomp-cli/src/tui/events.rs` - Added key bindings for content search
- `crates/hbc-decomp-cli/src/tui/ui.rs` - Added search popup UI and match highlighting

## Demo
<img width="1488" height="1366" alt="hermes-decomp-tui-search" src="https://github.com/user-attachments/assets/0b65b301-8880-4ef5-8648-ad2ed10063f0" />


## Testing
1. Run TUI: `hermes-decomp tui <file>`
2. Select a function with `j`/`k`
3. Press `s` to enter content search
4. Type a search term
5. Verify matches highlighted in yellow
6. Press `Enter`/`Down`/`Up` to navigate matches
7. Press `Esc` to exit