### PR TITLE
Add text selection and copy in the content pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
+ "base64",
  "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",

--- a/crates/hbc-decomp-cli/Cargo.toml
+++ b/crates/hbc-decomp-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 clap = { version = "4.5.0", features = ["derive"] }
 hbc-decomp = { path = "../hbc-decomp" }
 ratatui = "0.30"
-crossterm = "0.29"
+crossterm = { version = "0.29", features = ["osc52"] }
 regex = "1.10"
 serde_json = "1.0"
 log = "0.4.29"

--- a/crates/hbc-decomp-cli/src/tui/app.rs
+++ b/crates/hbc-decomp-cli/src/tui/app.rs
@@ -171,6 +171,12 @@ pub struct App {
     pub pipeline_ctx2: Option<Arc<PipelineContext>>,
     pub pipeline_rx2: Option<Receiver<PipelineContext>>,
     pub pipeline_building2: bool,
+
+    // Text selection (terminal cell coordinates, content pane only)
+    pub selection_anchor: Option<(u16, u16)>,
+    pub selection_target: Option<(u16, u16)>,
+    pub selecting: bool,
+    pub content_inner: Rect,
 }
 
 impl App {
@@ -301,6 +307,10 @@ impl App {
             pipeline_ctx2: None,
             pipeline_rx2: None,
             pipeline_building2: false,
+            selection_anchor: None,
+            selection_target: None,
+            selecting: false,
+            content_inner: Rect::default(),
         };
 
         let map1_start = Instant::now();
@@ -463,11 +473,93 @@ impl App {
         }
     }
 
+    pub fn is_inside_content(&self, col: u16, row: u16) -> bool {
+        let r = self.content_inner;
+        col >= r.x && col < r.x + r.width && row >= r.y && row < r.y + r.height
+    }
+
+    pub fn normalized_selection(&self) -> Option<(u16, u16, u16, u16)> {
+        let (ac, ar) = self.selection_anchor?;
+        let (tc, tr) = self.selection_target?;
+        let (sc, sr, ec, er) = if (ar, ac) <= (tr, tc) {
+            (ac, ar, tc, tr)
+        } else {
+            (tc, tr, ac, ar)
+        };
+        Some((sc, sr, ec, er))
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.selection_anchor = None;
+        self.selection_target = None;
+        self.selecting = false;
+    }
+
+    /// Push the current selection to the terminal clipboard via OSC 52 so
+    /// that Cmd+C / Ctrl+Shift+C copies it.  No-op when there is no
+    /// selection or the extracted text is empty.
+    pub fn copy_selection_to_clipboard(&mut self) {
+        use crossterm::clipboard::CopyToClipboard;
+        use crossterm::execute;
+
+        let Some((sel_sc, sel_sr, sel_ec, sel_er)) = self.normalized_selection() else {
+            return;
+        };
+
+        let (content, _) = self.content();
+        let inner = self.content_inner;
+        let scroll = self.scroll as u16;
+
+        let mut result = String::new();
+        for vi in 0..inner.height {
+            let term_row = inner.y + vi;
+            let line_idx = vi + scroll;
+            if term_row < sel_sr || term_row > sel_er || line_idx as usize >= content.lines.len() {
+                if term_row > sel_er {
+                    break;
+                }
+                continue;
+            }
+
+            let line = &content.lines[line_idx as usize];
+            let line_text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+
+            let col_start = if term_row == sel_sr {
+                sel_sc.saturating_sub(inner.x) as usize
+            } else {
+                0
+            };
+            let col_end = if term_row == sel_er {
+                ((sel_ec + 1).min(inner.x + inner.width) - inner.x) as usize
+            } else {
+                line_text.len()
+            };
+            let col_start = col_start.min(line_text.len());
+            let col_end = col_end.min(line_text.len());
+            if col_start < col_end {
+                result.push_str(&line_text[col_start..col_end]);
+            }
+            if term_row < sel_er {
+                result.push('\n');
+            }
+        }
+
+        if result.is_empty() {
+            return;
+        }
+
+        let _ = execute!(
+            std::io::stdout(),
+            CopyToClipboard::to_clipboard_from(result)
+        );
+    }
+
     pub fn set_selected(&mut self, index: usize) {
         if self.selected != index {
             self.selected = index;
             self.list_state.select(Some(index));
             self.scroll = 0;
+            self.clear_selection();
         }
     }
 
@@ -483,6 +575,7 @@ impl App {
             }
             self.view = view;
             self.scroll = 0;
+            self.clear_selection();
         }
     }
 

--- a/crates/hbc-decomp-cli/src/tui/events.rs
+++ b/crates/hbc-decomp-cli/src/tui/events.rs
@@ -203,17 +203,37 @@ fn handle_key(app: &mut App, key: KeyEvent) -> bool {
     false
 }
 
-// Mouse: wheel scrolls the active view, left click selects a function in the
-// list (normal mode).
+// Mouse: wheel scrolls, left click selects functions or starts text selection
+// in the content pane.  On release the selected text is pushed to the terminal
+// clipboard via OSC 52 so Cmd+C / Ctrl+Shift+C works.
 fn handle_mouse(app: &mut App, me: MouseEvent) {
     match me.kind {
         MouseEventKind::ScrollDown => app.scroll = app.scroll.saturating_add(3),
         MouseEventKind::ScrollUp => app.scroll = app.scroll.saturating_sub(3),
         MouseEventKind::Down(MouseButton::Left) => {
             if app.git_diff {
-                app.git_toggle_fold_at(me.row); // click a ▼/▶ header to fold
+                app.git_toggle_fold_at(me.row);
+            } else if app.is_inside_content(me.column, me.row) {
+                app.selection_anchor = Some((me.column, me.row));
+                app.selection_target = Some((me.column, me.row));
+                app.selecting = true;
             } else {
                 app.select_at_row(me.column, me.row);
+                app.clear_selection();
+            }
+        }
+        MouseEventKind::Drag(MouseButton::Left) => {
+            if app.selecting {
+                app.selection_target = Some((me.column, me.row));
+            }
+        }
+        MouseEventKind::Up(MouseButton::Left) => {
+            if app.selecting {
+                app.selecting = false;
+                // Only copy when the user actually dragged (anchor != target).
+                if app.selection_anchor != app.selection_target {
+                    app.copy_selection_to_clipboard();
+                }
             }
         }
         _ => {}

--- a/crates/hbc-decomp-cli/src/tui/ui.rs
+++ b/crates/hbc-decomp-cli/src/tui/ui.rs
@@ -254,7 +254,7 @@ fn draw_content_pane(
         None
     };
 
-    let highlighted: Vec<Line<'static>> = if q.is_some() {
+    let mut highlighted: Vec<Line<'static>> = if q.is_some() {
         content
             .lines
             .into_iter()
@@ -263,6 +263,42 @@ fn draw_content_pane(
     } else {
         content.lines
     };
+
+    // Record inner area for coordinate mapping.
+    let inner = Block::default().borders(Borders::ALL).inner(area);
+    app.content_inner = inner;
+
+    // Overlay text selection highlight (reverse video).
+    if let Some((sel_sc, sel_sr, sel_ec, sel_er)) = app.normalized_selection() {
+        let scroll = app.scroll as u16;
+        for vi in 0..inner.height {
+            let term_row = inner.y + vi;
+            let line_idx = vi + scroll;
+            if line_idx as usize >= highlighted.len() {
+                break;
+            }
+            if term_row < sel_sr || term_row > sel_er {
+                continue;
+            }
+            let col_start = if term_row == sel_sr {
+                sel_sc
+            } else {
+                inner.x
+            };
+            let col_end = if term_row == sel_er {
+                (sel_ec + 1).min(inner.x + inner.width)
+            } else {
+                inner.x + inner.width
+            };
+            if col_start >= col_end {
+                continue;
+            }
+            let off = col_start.saturating_sub(inner.x) as usize;
+            let end = (col_end - inner.x) as usize;
+            highlighted[line_idx as usize] =
+                apply_selection_styling(&highlighted[line_idx as usize], off, end);
+        }
+    }
 
     let paragraph = Paragraph::new(highlighted)
         .block(
@@ -341,6 +377,47 @@ fn highlight_line_with_search(line: Line<'static>, query: Option<&str>) -> Line<
     }
 
     Line::from(result_spans)
+}
+
+// Apply reverse-video highlight to character range [start, end) on a line.
+// Splits spans at boundaries so only the selected portion is highlighted.
+fn apply_selection_styling(
+    line: &Line<'static>,
+    start: usize,
+    end: usize,
+) -> Line<'static> {
+    let sel = Style::default().add_modifier(Modifier::REVERSED);
+    let mut out = Vec::new();
+    let mut col = 0usize;
+
+    for span in &line.spans {
+        let len: usize = span
+            .content
+            .chars()
+            .map(|c| if c == '\t' { 4 } else { 1 })
+            .sum();
+        let span_end = col + len;
+
+        if span_end <= start || col >= end {
+            out.push(span.clone());
+        } else if col >= start && span_end <= end {
+            out.push(Span::styled(span.content.clone(), sel.patch(span.style)));
+        } else {
+            let mut cc = col;
+            for ch in span.content.chars() {
+                let w = if ch == '\t' { 4 } else { 1 };
+                let s = if cc >= start && cc < end {
+                    sel.patch(span.style)
+                } else {
+                    span.style
+                };
+                out.push(Span::styled(ch.to_string(), s));
+                cc += w;
+            }
+        }
+        col = span_end;
+    }
+    Line::from(out)
 }
 
 // One side of a diff row: git-style sign (`+`/`-`/space), a line-number


### PR DESCRIPTION
## Summary

Add drag-to-select in the TUI content pane with clipboard copy via OSC 52. Selected text gets a reverse-video highlight, and on release is pushed to the terminal clipboard so Cmd+C / Ctrl+Shift+C works natively.

## Changes

### New Features
- Left-click and drag inside the disasm/decompile/info pane to select text
- Reverse-video highlight scoped to the content pane (doesn't bleed into borders or function list)
- On mouse release, selected text is copied to the terminal clipboard via OSC 52
- Cmd+C / Ctrl+Shift+C pastes the selection (works in iTerm2, Kitty, Alacritty, WezTerm, Ghostty)
- Selection clears on function change, view switch, or click outside the content pane

### Technical Details
- Enabled crossterm `osc52` feature for `CopyToClipboard` support
- `App` tracks `selection_anchor` / `selection_target` in terminal cell coordinates
- `apply_selection_styling` splits spans at selection boundaries and applies `Modifier::REVERSED`
- `copy_selection_to_clipboard` extracts text from the selected range and sends it via OSC 52

### Files Modified
- `crates/hbc-decomp-cli/Cargo.toml` - Enabled `osc52` feature on crossterm
- `crates/hbc-decomp-cli/src/tui/app.rs` - Added selection state, coordinate mapping, and clipboard copy logic
- `crates/hbc-decomp-cli/src/tui/events.rs` - Added mouse drag/up handling for selection
- `crates/hbc-decomp-cli/src/tui/ui.rs` - Added selection highlight rendering

### Demo

<img width="882" height="540" alt="hermes-selection" src="https://github.com/user-attachments/assets/bdd9deac-2253-4d09-9428-9d3ddf7f9f52" />


## Testing

1. Open TUI: `hermes-decomp tui <file>`
2. Select a function with `j`/`k`
3. Click and drag inside the content pane — reverse-video highlight appears
4. Release mouse — text is in the terminal clipboard
5. Cmd+C (macOS) / Ctrl+Shift+C (Linux), then paste elsewhere — correct text
6. Switch functions or views — selection clears
7. Click outside the content pane — selection clears
