### PR TITLE
Add inline callgraph/xref navigation to the TUI

### DIFF
--- a/crates/hbc-decomp-cli/src/tui/app.rs
+++ b/crates/hbc-decomp-cli/src/tui/app.rs
@@ -177,6 +177,18 @@ pub struct App {
     pub selection_target: Option<(u16, u16)>,
     pub selecting: bool,
     pub content_inner: Rect,
+
+    // Xref picker (g key)
+    pub xref_open: bool,
+    pub xref_list: Vec<(String, u32, XrefKind)>,
+    pub xref_selected: usize,
+    pub xref_scroll: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum XrefKind {
+    Callee,
+    Caller,
 }
 
 impl App {
@@ -311,6 +323,10 @@ impl App {
             selection_target: None,
             selecting: false,
             content_inner: Rect::default(),
+            xref_open: false,
+            xref_list: Vec::new(),
+            xref_selected: 0,
+            xref_scroll: 0,
         };
 
         let map1_start = Instant::now();
@@ -738,6 +754,96 @@ impl App {
                     .filter(|&&ri| gitdiff::row_contains(&self.git_rows[ri], &query))
                     .count();
                 return;
+            }
+        }
+    }
+
+    pub fn open_xref(&mut self) {
+        let Some(func_id) = self.selected_function_id() else {
+            return;
+        };
+
+        let mut items: Vec<(String, u32, XrefKind)> = Vec::new();
+
+        if let Some(ctx) = &self.pipeline_ctx {
+            let graph = &ctx.global_analysis.graph;
+
+            if let Some(callees) = graph.calls.get(&func_id) {
+                let mut seen = std::collections::BTreeSet::new();
+                for &callee in callees {
+                    if seen.insert(callee) {
+                        let name = self.func_name_by_id(callee);
+                        items.push((name, callee, XrefKind::Callee));
+                    }
+                }
+            }
+
+            if let Some(callers) = graph.callers.get(&func_id) {
+                let mut seen = std::collections::BTreeSet::new();
+                for &caller in callers {
+                    if seen.insert(caller) {
+                        let name = self.func_name_by_id(caller);
+                        items.push((name, caller, XrefKind::Caller));
+                    }
+                }
+            }
+        } else {
+            let refs = hbc_decomp::analysis::find_function_refs(
+                &self.file, &self.format, func_id,
+            );
+            let mut seen = std::collections::BTreeSet::new();
+            for xref in &refs {
+                if seen.insert(xref.function_id) {
+                    let name = self.func_name_by_id(xref.function_id);
+                    items.push((name, xref.function_id, XrefKind::Caller));
+                }
+            }
+
+            self.ensure_pipeline_building();
+        }
+
+        items.sort_by(|a, b| {
+            a.2.cmp(&b.2).then_with(|| a.0.cmp(&b.0))
+        });
+
+        self.xref_list = items;
+        self.xref_selected = 0;
+        self.xref_scroll = 0;
+        self.xref_open = !self.xref_list.is_empty();
+    }
+
+    fn func_name_by_id(&self, id: u32) -> String {
+        self.map1
+            .iter()
+            .find(|(_, &fid)| fid == id)
+            .map(|(name, _)| name.clone())
+            .unwrap_or_else(|| {
+                self.file
+                    .string_at(
+                        self.file
+                            .function_headers
+                            .get(id as usize)
+                            .map(|h| h.function_name())
+                            .unwrap_or(0),
+                    )
+                    .map(|e| e.value.clone())
+                    .filter(|v| !v.is_empty())
+                    .unwrap_or_else(|| format!("f{id}"))
+            })
+    }
+
+    pub fn xref_jump(&mut self) {
+        if let Some((name, _, _)) = self.xref_list.get(self.xref_selected).cloned() {
+            self.xref_open = false;
+            let idx = self.function_names.iter().position(|n| n == &name);
+            if let Some(idx) = idx {
+                self.set_selected(idx);
+            } else {
+                self.search_query.clear();
+                self.update_search();
+                if let Some(idx) = self.function_names.iter().position(|n| n == &name) {
+                    self.set_selected(idx);
+                }
             }
         }
     }

--- a/crates/hbc-decomp-cli/src/tui/events.rs
+++ b/crates/hbc-decomp-cli/src/tui/events.rs
@@ -114,6 +114,11 @@ fn handle_key(app: &mut App, key: KeyEvent) -> bool {
         return false;
     }
 
+    // Xref picker mode
+    if app.xref_open {
+        return handle_xref_key(app, key);
+    }
+
     // Full-program git diff is a separate full-screen mode with its own keys.
     if app.git_diff {
         return handle_git_key(app, key);
@@ -129,15 +134,15 @@ fn handle_key(app: &mut App, key: KeyEvent) -> bool {
         }
         KeyCode::Char('d') => {
             app.show_diff_colors = !app.show_diff_colors;
-            // Force redraw/recalc if needed?
-            // The content() method checks this flag, so next draw will pick it up.
-            // But we might want to clear cache?
             app.disasm_cache.clear();
             app.decompile_cache.clear();
             app.disasm_cache2.clear();
             app.decompile_cache2.clear();
         }
         KeyCode::Char('q') => return true,
+        KeyCode::Char('g') => {
+            app.open_xref();
+        }
         KeyCode::Up | KeyCode::Char('k') => {
             if app.selected > 0 {
                 app.set_selected(app.selected - 1);
@@ -300,6 +305,35 @@ fn handle_git_key(app: &mut App, key: KeyEvent) -> bool {
         KeyCode::PageUp => app.scroll = app.scroll.saturating_sub(20),
         KeyCode::Home => app.scroll = 0,
         KeyCode::End => app.scroll = u32::MAX, // clamped during rendering
+        _ => {}
+    }
+    false
+}
+
+fn handle_xref_key(app: &mut App, key: KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Esc => {
+            app.xref_open = false;
+        }
+        KeyCode::Enter => {
+            app.xref_jump();
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if app.xref_selected + 1 < app.xref_list.len() {
+                app.xref_selected += 1;
+            }
+        }
+        KeyCode::Up | KeyCode::Char('k') => {
+            if app.xref_selected > 0 {
+                app.xref_selected -= 1;
+            }
+        }
+        KeyCode::PageDown => {
+            app.xref_selected = (app.xref_selected + 10).min(app.xref_list.len().saturating_sub(1));
+        }
+        KeyCode::PageUp => {
+            app.xref_selected = app.xref_selected.saturating_sub(10);
+        }
         _ => {}
     }
     false

--- a/crates/hbc-decomp-cli/src/tui/ui.rs
+++ b/crates/hbc-decomp-cli/src/tui/ui.rs
@@ -4,7 +4,7 @@ use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Block, BorderType, Borders, Clear, List, ListItem, Paragraph, Wrap};
 use ratatui::Frame;
 
-use super::app::{App, ViewMode};
+use super::app::{App, ViewMode, XrefKind};
 use super::diff::DiffStatus;
 use super::formatting::highlight_code;
 
@@ -95,6 +95,8 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App) {
             Span::styled(" view ", Style::default().fg(Color::DarkGray)),
             Span::styled("PgUp/Dn", Style::default().fg(Color::White)),
             Span::styled(" scroll ", Style::default().fg(Color::DarkGray)),
+            Span::styled("g", Style::default().fg(Color::White)),
+            Span::styled(" xref ", Style::default().fg(Color::DarkGray)),
             Span::styled("d", Style::default().fg(Color::White)),
             Span::styled(" diff colors ", Style::default().fg(Color::DarkGray)),
             Span::styled("v", Style::default().fg(Color::White)),
@@ -125,6 +127,8 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App) {
             Span::styled(" view ", Style::default().fg(Color::DarkGray)),
             Span::styled("PgUp/Dn", Style::default().fg(Color::White)),
             Span::styled(" scroll ", Style::default().fg(Color::DarkGray)),
+            Span::styled("g", Style::default().fg(Color::White)),
+            Span::styled(" xref ", Style::default().fg(Color::DarkGray)),
             Span::styled("1-3", Style::default().fg(Color::White)),
             Span::styled(" views", Style::default().fg(Color::DarkGray)),
         ])
@@ -161,6 +165,10 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App) {
             ),
             popup,
         );
+    }
+
+    if app.xref_open {
+        draw_xref_popup(frame, app);
     }
 }
 
@@ -676,6 +684,59 @@ fn draw_git_diff(frame: &mut Frame, app: &mut App) {
             popup,
         );
     }
+}
+
+fn draw_xref_popup(frame: &mut Frame, app: &App) {
+    let popup = centered_rect(56, 20, frame.area());
+    frame.render_widget(Clear, popup);
+
+    let callee_style = Style::default().fg(Color::Cyan);
+    let caller_style = Style::default().fg(Color::Yellow);
+    let sel_style = Style::default().fg(Color::Black).bg(Color::Yellow);
+
+    let max_visible = (popup.height.saturating_sub(2)) as usize;
+    let scroll = if app.xref_selected >= max_visible {
+        app.xref_selected - max_visible + 1
+    } else {
+        0
+    };
+
+    let items: Vec<Line<'static>> = app
+        .xref_list
+        .iter()
+        .enumerate()
+        .skip(scroll)
+        .take(max_visible)
+        .map(|(idx, (name, _, kind))| {
+            let (label, style) = match kind {
+                XrefKind::Callee => ("-> ", callee_style),
+                XrefKind::Caller => ("<- ", caller_style),
+            };
+            let full = format!("{label}{name}");
+            if idx == app.xref_selected {
+                Line::from(Span::styled(full, sel_style))
+            } else {
+                Line::from(Span::styled(full, style))
+            }
+        })
+        .collect();
+
+    let callee_count = app.xref_list.iter().filter(|(_, _, k)| *k == XrefKind::Callee).count();
+    let caller_count = app.xref_list.iter().filter(|(_, _, k)| *k == XrefKind::Caller).count();
+    let title = format!(
+        " Xrefs: {} callees, {} callers — Enter: jump  Esc: close ",
+        callee_count, caller_count
+    );
+
+    frame.render_widget(
+        Paragraph::new(items).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Double)
+                .title(title),
+        ),
+        popup,
+    );
 }
 
 // A `Rect` of the given size centered within `area`.


### PR DESCRIPTION
## Summary

Add inline callgraph/xref navigation to the TUI. Press `g` on any function to open a picker listing its callees (functions it calls) and callers (functions that call it). Select an entry and press Enter to jump directly to that function  "Go to Definition" / "Find All References" for a decompiler TUI.

## Changes

### New Features
- Press `g` to open a cross-reference picker popup for the selected function
- Callees shown with `->` prefix in cyan, callers with `<-` prefix in yellow
- Navigate with `j`/`k`, `PgUp`/`PgDn`; `Enter` jumps to the target function
- `Esc` closes the picker without action
- Jump clears the search filter if the target function is filtered out

### Technical Details
- Uses `PipelineContext.global_analysis.graph` (`CallGraph` with `calls` and `callers` maps) when the pipeline is built
- Falls back to `find_function_refs` bytecode-level scan (callers only) when the pipeline isn't ready yet, and triggers pipeline build in the background
- `XrefKind` enum distinguishes callee vs caller entries; list sorted by kind then name
- Picker rendering reuses the centered popup pattern from content search (`s`)
- `xref_jump()` resolves the target function name to its index in the filtered function list

### Files Modified
- `crates/hbc-decomp-cli/src/tui/app.rs` - Added `XrefKind` enum, `xref_open`/`xref_list`/`xref_selected`/`xref_scroll` fields, `open_xref()`, `func_name_by_id()`, `xref_jump()` methods
- `crates/hbc-decomp-cli/src/tui/events.rs` - Added `g` key binding, `handle_xref_key()` for picker navigation and jump
- `crates/hbc-decomp-cli/src/tui/ui.rs` - Added `draw_xref_popup()` rendering, `g xref` in footer help text

## Demo

<img width="1497" height="1299" alt="hermes-decomp-tui-xref" src="https://github.com/user-attachments/assets/f618c868-c5b6-4104-9b64-8464ec35148c" />


## Testing

1. Open TUI: `hermes-decomp tui <file.hbc>`
2. Select a function with `j`/`k`
3. Press `g`  popup appears listing callees (`->`) and callers (`<-`)
4. Navigate with `j`/`k`, press `Enter`, view jumps to the selected function
5. Press `Esc`  picker closes without changing selection
6. Test with pipeline not yet built, callers still appear from bytecode scan
7. Test with pipeline built, both callees and callers appear
8. Test jump to a function that's filtered out by current search — search filter clears and jump succeeds
