### PR TITLE
Add self-update command via GitHub releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,6 +964,7 @@ dependencies = [
  "sha2",
  "similar",
  "tar",
+ "tempfile",
  "ureq",
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,12 +186,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,17 +286,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,25 +369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "unicode-width",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,15 +388,6 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -526,33 +481,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,16 +554,6 @@ name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
-
-[[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "zeroize",
-]
 
 [[package]]
 name = "deranged"
@@ -713,41 +631,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2",
- "signature",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
@@ -818,12 +705,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -1001,10 +882,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1026,30 +905,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
- "rand_core 0.10.1",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -1096,13 +953,19 @@ dependencies = [
  "clap",
  "crossterm",
  "env_logger",
+ "flate2",
  "hbc-decomp",
  "log",
  "ratatui",
  "regex",
- "self_update",
+ "self-replace",
+ "semver",
  "serde_json",
+ "sha2",
  "similar",
+ "tar",
+ "ureq",
+ "zip",
 ]
 
 [[package]]
@@ -1186,7 +1049,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1195,23 +1057,6 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.27.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
-dependencies = [
- "http",
- "hyper",
- "hyper-util",
- "rustls",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1220,21 +1065,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
  "bytes",
- "futures-channel",
- "futures-util",
  "http",
  "http-body",
  "hyper",
- "ipnet",
- "libc",
- "percent-encoding",
  "pin-project-lite",
- "socket2",
  "tokio",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1380,19 +1217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.17.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
-dependencies = [
- "console",
- "number_prefix",
- "portable-atomic",
- "unicode-width",
- "web-time",
-]
-
-[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,12 +1237,6 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1562,12 +1380,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,12 +1507,6 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -1890,16 +1696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,71 +1744,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.37.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,17 +1784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.3",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2078,9 +1798,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
 
 [[package]]
 name = "rand_core"
@@ -2089,21 +1806,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2286,47 +1988,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,12 +2045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2417,6 +2072,7 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2431,7 +2087,6 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -2499,30 +2154,6 @@ dependencies = [
  "fastrand",
  "tempfile",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "self_update"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
-dependencies = [
- "either",
- "flate2",
- "hyper",
- "indicatif",
- "log",
- "quick-xml",
- "regex",
- "reqwest",
- "self-replace",
- "semver",
- "serde_json",
- "tar",
- "tempfile",
- "urlencoding",
- "zip",
- "zipsign-api",
 ]
 
 [[package]]
@@ -2615,7 +2246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -2657,16 +2288,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest",
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2704,16 +2325,6 @@ checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -2801,9 +2412,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -2988,21 +2596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3028,16 +2621,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
-dependencies = [
- "rustls",
- "tokio",
 ]
 
 [[package]]
@@ -3078,24 +2661,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
-dependencies = [
- "bitflags 2.13.0",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "url",
 ]
 
 [[package]]
@@ -3141,12 +2706,6 @@ checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
-
-[[package]]
-name = "try-lock"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
@@ -3196,6 +2755,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3206,12 +2781,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3253,15 +2822,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "want"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
-dependencies = [
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,20 +2847,6 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
-dependencies = [
- "cfg-if",
- "futures-util",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3336,23 +2882,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "webpki-roots"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3522,15 +3057,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3817,21 +3343,11 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
+ "flate2",
  "indexmap",
  "memchr",
  "thiserror 2.0.18",
- "time",
-]
-
-[[package]]
-name = "zipsign-api"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
-dependencies = [
- "base64",
- "ed25519-dalek",
- "thiserror 2.0.18",
+ "zopfli",
 ]
 
 [[package]]
@@ -3839,3 +3355,15 @@ name = "zmij"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +98,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +184,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -271,6 +292,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +386,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +426,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -457,6 +526,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -532,10 +628,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "derive_more"
@@ -570,6 +687,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,10 +713,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "signature",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "env_filter"
@@ -655,6 +814,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "filedescriptor"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +834,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -682,6 +863,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -805,6 +996,19 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
@@ -822,8 +1026,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -874,6 +1100,7 @@ dependencies = [
  "log",
  "ratatui",
  "regex",
+ "self_update",
  "serde_json",
  "similar",
 ]
@@ -959,6 +1186,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -967,6 +1195,23 @@ dependencies = [
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -975,13 +1220,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1009,10 +1262,135 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
 
 [[package]]
 name = "indoc"
@@ -1035,6 +1413,12 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1142,6 +1526,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "litrs"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1560,12 @@ checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
  "hashbrown 0.17.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac_address"
@@ -1219,6 +1615,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1289,6 +1695,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -1478,6 +1890,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1912,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1514,6 +1945,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1557,6 +2053,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +2078,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -1579,6 +2089,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1761,6 +2286,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rmcp"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1804,6 +2384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +2409,41 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1868,6 +2489,41 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "self_update"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832c086ece0dacc29fb2947bb4219b8f6e12fe9e40b7108f9e57c4224e47b5c"
+dependencies = [
+ "either",
+ "flate2",
+ "hyper",
+ "indicatif",
+ "log",
+ "quick-xml",
+ "regex",
+ "reqwest",
+ "self-replace",
+ "semver",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "urlencoding",
+ "zip",
+ "zipsign-api",
+]
 
 [[package]]
 name = "semver"
@@ -1959,7 +2615,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2001,6 +2657,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,6 +2707,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "sse-stream"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2046,6 +2728,12 @@ dependencies = [
  "http-body-util",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2081,6 +2769,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,6 +2801,44 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "termina"
@@ -2246,6 +2978,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2271,6 +3028,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -2311,6 +3078,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2358,6 +3143,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +3190,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,6 +3253,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +3287,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2489,6 +3333,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2646,11 +3519,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2664,20 +3555,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2687,9 +3600,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2699,9 +3624,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2711,15 +3648,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2732,6 +3687,45 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -2751,6 +3745,93 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "indexmap",
+ "memchr",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "zipsign-api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "hbc-decomp"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "bincode",
  "colored",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "hbc-decomp-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "clap",
  "crossterm",
@@ -1107,7 +1107,7 @@ dependencies = [
 
 [[package]]
 name = "hbc-decomp-mcp"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -104,6 +104,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -186,15 +197,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,9 +252,9 @@ checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "castaway"
@@ -286,16 +288,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -393,6 +404,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -482,36 +502,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.114",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -529,22 +525,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.114",
 ]
@@ -907,6 +892,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -935,12 +921,12 @@ dependencies = [
 name = "hbc-decomp"
 version = "0.1.7"
 dependencies = [
- "bincode",
  "colored",
  "env_logger",
  "log",
  "rayon",
  "regex",
+ "rmp-serde",
  "serde",
  "serde_json",
  "sha2",
@@ -1231,7 +1217,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
@@ -1577,10 +1563,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pastey"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -1726,15 +1712,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1775,22 +1752,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1801,12 +1769,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -2003,10 +1968,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.8.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5947688160b56fb6c827e3c20a72c90392a1d7e9dec74749197aa1780ac42ca"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
+ "async-trait",
  "base64",
  "bytes",
  "chrono",
@@ -2014,9 +1980,9 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "paste",
+ "pastey",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.10.2",
  "rmcp-macros",
  "schemars",
  "serde",
@@ -2033,15 +1999,34 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.8.5"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01263441d3f8635c628e33856c468b96ebbce1af2d3699ea712ca71432d4ee7a"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
- "darling 0.21.3",
+ "darling",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -2246,7 +2231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -3251,26 +3236,6 @@ dependencies = [
  "quote",
  "syn 2.0.114",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,6 @@ dependencies = [
  "sha2",
  "similar",
  "tar",
- "tempfile",
  "ureq",
  "zip",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
 ]
 
 [workspace.package]
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/SymbioticSec/hermes-decomp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.7"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/SymbioticSec/hermes-decomp"

--- a/crates/hbc-decomp-cli/Cargo.toml
+++ b/crates/hbc-decomp-cli/Cargo.toml
@@ -27,7 +27,6 @@ ureq = { version = "2", default-features = false, features = ["tls", "gzip"] }
 semver = "1"
 sha2 = "0.10"
 self-replace = "1"
-tempfile = "3"
 flate2 = "1"
 tar = "0.4"
 

--- a/crates/hbc-decomp-cli/Cargo.toml
+++ b/crates/hbc-decomp-cli/Cargo.toml
@@ -20,3 +20,7 @@ serde_json = "1.0"
 log = "0.4.29"
 env_logger = "0.11.9"
 similar = "2.7.0"
+self_update = { version = "0.42", default-features = false, features = ["rustls", "archive-zip", "compression-flate2"] }
+
+[package.metadata.binstall]
+bin = "hermes-decomp"

--- a/crates/hbc-decomp-cli/Cargo.toml
+++ b/crates/hbc-decomp-cli/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "hbc-decomp-cli"
-version = "0.1.6"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "CLI tool to decompile Hermes bytecode (.hbc) from React Native apps"
-repository = "https://github.com/SymbioticSec/hermes-decomp"
+repository.workspace = true
 
 [[bin]]
 name = "hermes-decomp"

--- a/crates/hbc-decomp-cli/Cargo.toml
+++ b/crates/hbc-decomp-cli/Cargo.toml
@@ -20,7 +20,18 @@ serde_json = "1.0"
 log = "0.4.29"
 env_logger = "0.11.9"
 similar = "2.7.0"
-self_update = { version = "0.42", default-features = false, features = ["rustls", "archive-zip", "compression-flate2"] }
+
+# Self-update: a lightweight synchronous stack (no tokio/hyper) that verifies the
+# downloaded archive's SHA-256 against the release SHA256SUMS before installing.
+ureq = { version = "2", default-features = false, features = ["tls", "gzip"] }
+semver = "1"
+sha2 = "0.10"
+self-replace = "1"
+flate2 = "1"
+tar = "0.4"
+
+[target.'cfg(windows)'.dependencies]
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [package.metadata.binstall]
 bin = "hermes-decomp"

--- a/crates/hbc-decomp-cli/Cargo.toml
+++ b/crates/hbc-decomp-cli/Cargo.toml
@@ -27,6 +27,7 @@ ureq = { version = "2", default-features = false, features = ["tls", "gzip"] }
 semver = "1"
 sha2 = "0.10"
 self-replace = "1"
+tempfile = "3"
 flate2 = "1"
 tar = "0.4"
 

--- a/crates/hbc-decomp-cli/src/cli_args.rs
+++ b/crates/hbc-decomp-cli/src/cli_args.rs
@@ -343,6 +343,18 @@ pub enum Command {
         #[arg(long, value_enum, default_value = "auto")]
         function_layout: FunctionLayoutArg,
     },
+    /// Check for and install updates from GitHub releases.
+    Update {
+        /// Just print the latest version + release notes, do not download.
+        #[arg(long)]
+        check: bool,
+        /// Install the update in place (replaces the current binary).
+        #[arg(long)]
+        install: bool,
+        /// Update to a specific version (e.g. "v0.1.7" or "0.1.7").
+        #[arg(long)]
+        version: Option<String>,
+    },
 }
 
 #[derive(ValueEnum, Clone, Copy, Debug)]

--- a/crates/hbc-decomp-cli/src/commands/mod.rs
+++ b/crates/hbc-decomp-cli/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod debug_cmd;
 pub mod decompile_cmd;
 pub mod dump_cmd;
 pub mod extract_cmd;
+pub mod update_cmd;

--- a/crates/hbc-decomp-cli/src/commands/update_cmd.rs
+++ b/crates/hbc-decomp-cli/src/commands/update_cmd.rs
@@ -1,57 +1,214 @@
-use self_update::backends::github::Update;
-use self_update::update::ReleaseUpdate;
+//! Self-update via GitHub releases.
+//!
+//! Uses a lightweight synchronous stack (ureq, no tokio/hyper). The downloaded
+//! archive is verified against the release `SHA256SUMS` before the running
+//! binary is replaced, and version comparison uses the `semver` crate.
 
-const REPO_OWNER: &str = "SymbioticSec";
-const REPO_NAME: &str = "hermes-decomp";
+use std::error::Error;
+use std::io::Read;
+
+const REPO: &str = "SymbioticSec/hermes-decomp";
 const BIN_NAME: &str = "hermes-decomp";
 const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+const USER_AGENT: &str = concat!("hermes-decomp/", env!("CARGO_PKG_VERSION"));
+const MAX_DOWNLOAD: u64 = 256 * 1024 * 1024; // 256 MiB cap on any download
 
-fn target_triple() -> &'static str {
-    if cfg!(target_os = "linux") {
-        if cfg!(target_arch = "x86_64") {
-            "linux-x86_64"
-        } else if cfg!(target_arch = "aarch64") {
-            "linux-arm64"
-        } else {
-            "linux"
-        }
-    } else if cfg!(target_os = "macos") {
-        if cfg!(target_arch = "aarch64") {
-            "macos-arm64"
-        } else if cfg!(target_arch = "x86_64") {
-            "macos-x86_64"
-        } else {
-            "macos"
-        }
-    } else if cfg!(target_os = "windows") {
-        if cfg!(target_arch = "x86_64") {
-            "windows-x86_64"
-        } else {
-            "windows"
-        }
-    } else {
-        "unknown"
-    }
-}
+type Res<T> = Result<T, Box<dyn Error>>;
 
-fn build_updater(target_suffix: &str) -> Result<Box<dyn ReleaseUpdate>, Box<dyn std::error::Error>> {
-    let asset_name = format!("{}.{}", target_suffix, archive_ext());
-    let updater = Update::configure()
-        .repo_owner(REPO_OWNER)
-        .repo_name(REPO_NAME)
-        .bin_name(BIN_NAME)
-        .current_version(PKG_VERSION)
-        .target(&asset_name)
-        .show_download_progress(true)
-        .show_output(false)
-        .no_confirm(true)
-        .build()?;
-    Ok(updater)
+// --- platform / asset naming ---------------------------------------------------
+
+/// The platform suffix used in release asset names, or `None` if unsupported.
+fn platform_suffix() -> Option<&'static str> {
+    Some(match (std::env::consts::OS, std::env::consts::ARCH) {
+        ("linux", "x86_64") => "linux-x86_64",
+        ("linux", "aarch64") => "linux-arm64",
+        ("macos", "aarch64") => "macos-arm64",
+        ("macos", "x86_64") => "macos-x86_64",
+        ("windows", "x86_64") => "windows-x86_64",
+        _ => return None,
+    })
 }
 
 fn archive_ext() -> &'static str {
-    if cfg!(target_os = "windows") { "zip" } else { "tar.gz" }
+    if cfg!(windows) {
+        "zip"
+    } else {
+        "tar.gz"
+    }
 }
+
+/// Exact release asset name for this platform, e.g.
+/// `hermes-decomp-v0.1.6-macos-arm64.tar.gz`. `tag` is the release tag (`v0.1.6`).
+fn asset_name(tag: &str, suffix: &str) -> String {
+    format!("hermes-decomp-{tag}-{suffix}.{}", archive_ext())
+}
+
+// --- GitHub API ----------------------------------------------------------------
+
+struct Release {
+    tag: String,
+    version: semver::Version,
+    body: Option<String>,
+    assets: Vec<(String, String)>, // (name, download_url)
+}
+
+impl Release {
+    fn asset_url(&self, name: &str) -> Option<&str> {
+        self.assets
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, u)| u.as_str())
+    }
+}
+
+fn parse_version(tag: &str) -> Result<semver::Version, semver::Error> {
+    semver::Version::parse(tag.trim_start_matches('v'))
+}
+
+fn http_get(url: &str) -> Res<ureq::Response> {
+    ureq::get(url)
+        .set("User-Agent", USER_AGENT)
+        .set("Accept", "application/vnd.github+json")
+        .call()
+        .map_err(|e| e.into())
+}
+
+fn get_release(tag: Option<&str>) -> Res<Release> {
+    let url = match tag {
+        Some(t) => format!("https://api.github.com/repos/{REPO}/releases/tags/{t}"),
+        None => format!("https://api.github.com/repos/{REPO}/releases/latest"),
+    };
+    let text = http_get(&url)?.into_string()?;
+    let json: serde_json::Value = serde_json::from_str(&text)?;
+    parse_release(&json)
+}
+
+/// Parse a GitHub release JSON object into a `Release` (pure, unit-testable).
+fn parse_release(json: &serde_json::Value) -> Res<Release> {
+    let tag = json["tag_name"]
+        .as_str()
+        .ok_or("release JSON has no tag_name")?
+        .to_string();
+    let version = parse_version(&tag)?;
+    let body = json["body"].as_str().map(str::to_string);
+    let assets = json["assets"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|a| {
+                    Some((
+                        a["name"].as_str()?.to_string(),
+                        a["browser_download_url"].as_str()?.to_string(),
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(Release {
+        tag,
+        version,
+        body,
+        assets,
+    })
+}
+
+// --- download / checksum -------------------------------------------------------
+
+fn download_bytes(url: &str) -> Res<Vec<u8>> {
+    let resp = ureq::get(url).set("User-Agent", USER_AGENT).call()?;
+    let mut buf = Vec::new();
+    resp.into_reader()
+        .take(MAX_DOWNLOAD)
+        .read_to_end(&mut buf)?;
+    Ok(buf)
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    hasher
+        .finalize()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// Look up the expected SHA-256 for `filename` inside a `SHA256SUMS` body.
+/// Each line is `<hex>  <name>` (a leading `*` on the name, from binary mode, is
+/// tolerated).
+fn expected_sha256(sha256sums: &str, filename: &str) -> Option<String> {
+    for line in sha256sums.lines() {
+        let mut parts = line.split_whitespace();
+        let sum = parts.next()?;
+        let name = parts.next()?;
+        if name.trim_start_matches('*') == filename {
+            return Some(sum.to_lowercase());
+        }
+    }
+    None
+}
+
+// --- archive extraction --------------------------------------------------------
+
+/// Extract the `hermes-decomp` binary bytes from the downloaded archive.
+#[cfg(not(windows))]
+fn extract_binary(archive: &[u8]) -> Res<Vec<u8>> {
+    let decoder = flate2::read::GzDecoder::new(archive);
+    let mut tar = tar::Archive::new(decoder);
+    for entry in tar.entries()? {
+        let mut entry = entry?;
+        let path = entry.path()?.to_string_lossy().to_string();
+        if path == BIN_NAME || path.ends_with(&format!("/{BIN_NAME}")) {
+            let mut data = Vec::new();
+            entry.read_to_end(&mut data)?;
+            return Ok(data);
+        }
+    }
+    Err(format!("`{BIN_NAME}` not found in the downloaded archive").into())
+}
+
+#[cfg(windows)]
+fn extract_binary(archive: &[u8]) -> Res<Vec<u8>> {
+    let reader = std::io::Cursor::new(archive);
+    let mut zip = zip::ZipArchive::new(reader)?;
+    let want = format!("{BIN_NAME}.exe");
+    for i in 0..zip.len() {
+        let mut file = zip.by_index(i)?;
+        let name = file.name().to_string();
+        if name == want || name.ends_with(&format!("/{want}")) {
+            let mut data = Vec::new();
+            file.read_to_end(&mut data)?;
+            return Ok(data);
+        }
+    }
+    Err(format!("`{BIN_NAME}.exe` not found in the downloaded archive").into())
+}
+
+/// Write the new binary to a sibling temp file, make it executable, then swap it
+/// into place atomically (handles the running-executable case on all platforms).
+fn replace_running_binary(binary: &[u8]) -> Res<()> {
+    let current = std::env::current_exe()?;
+    let dir = current.parent().ok_or("cannot locate install directory")?;
+    let tmp = dir.join(format!(".hermes-decomp-update-{}", std::process::id()));
+    std::fs::write(&tmp, binary)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755))?;
+    }
+
+    // self-replace swaps the currently running executable for `tmp`.
+    if let Err(e) = self_replace::self_replace(&tmp) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    let _ = std::fs::remove_file(&tmp);
+    Ok(())
+}
+
+// --- public API ----------------------------------------------------------------
 
 pub struct UpdateInfo {
     pub current: String,
@@ -60,91 +217,91 @@ pub struct UpdateInfo {
     pub update_available: bool,
 }
 
-pub fn check() -> Result<UpdateInfo, Box<dyn std::error::Error>> {
-    let target = target_triple();
-    let updater = build_updater(target)?;
-    let latest = updater.get_latest_release()?;
-    let latest_raw = latest.name.trim_start_matches('v').to_string();
-    let latest_tag = normalize_semver(&latest_raw);
-    let current_tag = normalize_semver(PKG_VERSION);
-    let update_available = is_newer(&latest_raw, PKG_VERSION);
+pub fn check() -> Res<UpdateInfo> {
+    let release = get_release(None)?;
+    let current = parse_version(PKG_VERSION)?;
+    let update_available = release.version > current;
     Ok(UpdateInfo {
-        current: current_tag,
-        latest: latest_tag,
-        notes: latest.body,
+        current: current.to_string(),
+        latest: release.version.to_string(),
+        notes: release.body,
         update_available,
     })
 }
 
-pub fn install(version: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
-    let target = target_triple();
-    let updater = if let Some(v) = version {
-        let tag = if v.starts_with('v') { v.to_string() } else { format!("v{}", v) };
-        let asset_name = format!("{}.{}", target, archive_ext());
-        Update::configure()
-            .repo_owner(REPO_OWNER)
-            .repo_name(REPO_NAME)
-            .bin_name(BIN_NAME)
-            .current_version(PKG_VERSION)
-            .target_version_tag(&tag)
-            .target(&asset_name)
-            .show_download_progress(true)
-            .show_output(false)
-            .no_confirm(true)
-            .build()?
-    } else {
-        build_updater(target)?
-    };
-    let status = updater.update()?;
-    log::info!("Update status: `{}`", status);
-    println!("Downloaded and installed. Restart hermes-decomp to use the new version.");
-    println!("(self_update reported: {:?})", status);
+pub fn install(version: Option<&str>) -> Res<()> {
+    let suffix = platform_suffix()
+        .ok_or_else(|| format!("no prebuilt binary for {}-{}", std::env::consts::OS, std::env::consts::ARCH))?;
+
+    let tag = version.map(|v| {
+        if v.starts_with('v') {
+            v.to_string()
+        } else {
+            format!("v{v}")
+        }
+    });
+    let release = get_release(tag.as_deref())?;
+
+    let asset = asset_name(&release.tag, suffix);
+    let asset_url = release
+        .asset_url(&asset)
+        .ok_or_else(|| format!("release {} has no asset `{asset}`", release.tag))?
+        .to_string();
+
+    // 1. Download the archive.
+    println!("Downloading {asset}...");
+    let archive = download_bytes(&asset_url)?;
+
+    // 2. Verify its SHA-256 against the release SHA256SUMS.
+    let sums_url = release
+        .asset_url("SHA256SUMS")
+        .ok_or("release has no SHA256SUMS asset to verify against")?;
+    let sums = String::from_utf8(download_bytes(sums_url)?)?;
+    let expected = expected_sha256(&sums, &asset)
+        .ok_or_else(|| format!("SHA256SUMS has no entry for `{asset}`"))?;
+    let actual = sha256_hex(&archive);
+    if actual != expected {
+        return Err(format!(
+            "checksum mismatch for `{asset}`\n  expected {expected}\n  actual   {actual}"
+        )
+        .into());
+    }
+    println!("Checksum OK ({}).", &actual[..16]);
+
+    // 3. Extract the binary and swap it in.
+    let binary = extract_binary(&archive)?;
+    replace_running_binary(&binary)?;
+
+    println!(
+        "Updated to {}. Restart hermes-decomp to use the new version.",
+        release.tag
+    );
     Ok(())
 }
 
-fn is_newer(latest: &str, current: &str) -> bool {
-    parse_semver(latest) > parse_semver(current)
-}
-
-fn parse_semver(s: &str) -> Vec<u64> {
-    s.trim_start_matches('v')
-        .split(|c: char| c == '.' || c == '-' || c == '+')
-        .filter_map(|p| p.parse::<u64>().ok())
-        .collect()
-}
-
-fn normalize_semver(s: &str) -> String {
-    parse_semver(s)
-        .iter()
-        .map(u64::to_string)
-        .collect::<Vec<_>>()
-        .join(".")
-}
-
-pub fn run(check_only: bool, install_now: bool, version: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(check_only: bool, install_now: bool, version: Option<String>) -> Res<()> {
     let do_install = install_now || (!check_only && version.is_some());
 
     if do_install {
         if version.is_none() {
             let info = check()?;
             if !info.update_available {
-                println!("Already on the latest version ({}).", info.current);
+                println!("Already on the latest version (v{}).", info.current);
                 return Ok(());
             }
             println!("Updating from v{} to v{}...", info.current, info.latest);
             if let Some(notes) = info.notes.as_deref() {
-                println!("\nChangelog:\n{}", notes);
+                println!("\nChangelog:\n{notes}");
             }
         }
-        install(version.as_deref())?;
-        return Ok(());
+        return install(version.as_deref());
     }
 
     let info = check()?;
     if info.update_available {
         println!("Update available: v{} -> v{}", info.current, info.latest);
         if let Some(notes) = info.notes.as_deref() {
-            println!("\nChangelog:\n{}", notes);
+            println!("\nChangelog:\n{notes}");
         }
         println!("\nRun `hermes-decomp update --install` to upgrade.");
     } else {
@@ -173,4 +330,82 @@ pub fn auto_check_on_startup() {
             }
         }
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semver_comparison_is_correct() {
+        // The old hand-rolled Vec<u64> compare got these wrong.
+        assert!(parse_version("v0.1.10").unwrap() > parse_version("v0.1.9").unwrap());
+        assert!(parse_version("0.2.0").unwrap() > parse_version("0.1.99").unwrap());
+        // A pre-release is older than its release.
+        assert!(parse_version("1.0.0-alpha").unwrap() < parse_version("1.0.0").unwrap());
+        assert_eq!(
+            parse_version("v1.2.3").unwrap(),
+            parse_version("1.2.3").unwrap()
+        );
+    }
+
+    #[test]
+    fn asset_name_is_exact() {
+        assert_eq!(
+            asset_name("v0.1.6", "macos-arm64"),
+            if cfg!(windows) {
+                "hermes-decomp-v0.1.6-macos-arm64.zip"
+            } else {
+                "hermes-decomp-v0.1.6-macos-arm64.tar.gz"
+            }
+        );
+    }
+
+    #[test]
+    fn parse_sha256sums_matches_and_tolerates_star() {
+        let sums = "\
+abc123  hermes-decomp-v0.1.6-linux-x86_64.tar.gz
+DEF456  hermes-decomp-v0.1.6-macos-arm64.tar.gz
+789aaa *hermes-decomp-v0.1.6-windows-x86_64.zip
+";
+        assert_eq!(
+            expected_sha256(sums, "hermes-decomp-v0.1.6-macos-arm64.tar.gz").as_deref(),
+            Some("def456")
+        );
+        assert_eq!(
+            expected_sha256(sums, "hermes-decomp-v0.1.6-windows-x86_64.zip").as_deref(),
+            Some("789aaa")
+        );
+        assert_eq!(expected_sha256(sums, "not-there.tar.gz"), None);
+    }
+
+    #[test]
+    fn sha256_hex_is_lowercase_hex_of_known_vector() {
+        // SHA-256 of the empty input.
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn parse_release_extracts_fields() {
+        let json = serde_json::json!({
+            "tag_name": "v0.1.6",
+            "body": "notes",
+            "assets": [
+                {"name": "SHA256SUMS", "browser_download_url": "https://x/SHA256SUMS"},
+                {"name": "hermes-decomp-v0.1.6-macos-arm64.tar.gz", "browser_download_url": "https://x/a"}
+            ]
+        });
+        let rel = parse_release(&json).unwrap();
+        assert_eq!(rel.tag, "v0.1.6");
+        assert_eq!(rel.version, semver::Version::new(0, 1, 6));
+        assert_eq!(rel.asset_url("SHA256SUMS"), Some("https://x/SHA256SUMS"));
+        assert_eq!(
+            rel.asset_url("hermes-decomp-v0.1.6-macos-arm64.tar.gz"),
+            Some("https://x/a")
+        );
+        assert_eq!(rel.asset_url("missing"), None);
+    }
 }

--- a/crates/hbc-decomp-cli/src/commands/update_cmd.rs
+++ b/crates/hbc-decomp-cli/src/commands/update_cmd.rs
@@ -1,8 +1,8 @@
-//! Self-update via GitHub releases.
-//!
-//! Uses a lightweight synchronous stack (ureq, no tokio/hyper). The downloaded
-//! archive is verified against the release `SHA256SUMS` before the running
-//! binary is replaced, and version comparison uses the `semver` crate.
+// Self-update via GitHub releases.
+//
+// Uses a lightweight synchronous stack (ureq, no tokio/hyper). The downloaded
+// archive is verified against the release `SHA256SUMS` before the running
+// binary is replaced, and version comparison uses the `semver` crate.
 
 use std::error::Error;
 use std::io::Read;
@@ -15,9 +15,7 @@ const MAX_DOWNLOAD: u64 = 256 * 1024 * 1024; // 256 MiB cap on any download
 
 type Res<T> = Result<T, Box<dyn Error>>;
 
-// --- platform / asset naming ---------------------------------------------------
-
-/// The platform suffix used in release asset names, or `None` if unsupported.
+// The platform suffix used in release asset names, or `None` if unsupported.
 fn platform_suffix() -> Option<&'static str> {
     Some(match (std::env::consts::OS, std::env::consts::ARCH) {
         ("linux", "x86_64") => "linux-x86_64",
@@ -37,13 +35,11 @@ fn archive_ext() -> &'static str {
     }
 }
 
-/// Exact release asset name for this platform, e.g.
-/// `hermes-decomp-v0.1.6-macos-arm64.tar.gz`. `tag` is the release tag (`v0.1.6`).
+// Exact release asset name for this platform, e.g.
+// `hermes-decomp-v0.1.6-macos-arm64.tar.gz`. `tag` is the release tag (`v0.1.6`).
 fn asset_name(tag: &str, suffix: &str) -> String {
     format!("hermes-decomp-{tag}-{suffix}.{}", archive_ext())
 }
-
-// --- GitHub API ----------------------------------------------------------------
 
 struct Release {
     tag: String,
@@ -83,7 +79,7 @@ fn get_release(tag: Option<&str>) -> Res<Release> {
     parse_release(&json)
 }
 
-/// Parse a GitHub release JSON object into a `Release` (pure, unit-testable).
+// Parse a GitHub release JSON object into a `Release` (pure, unit-testable).
 fn parse_release(json: &serde_json::Value) -> Res<Release> {
     let tag = json["tag_name"]
         .as_str()
@@ -112,8 +108,6 @@ fn parse_release(json: &serde_json::Value) -> Res<Release> {
     })
 }
 
-// --- download / checksum -------------------------------------------------------
-
 fn download_bytes(url: &str) -> Res<Vec<u8>> {
     let resp = ureq::get(url).set("User-Agent", USER_AGENT).call()?;
     let mut buf = Vec::new();
@@ -134,9 +128,9 @@ fn sha256_hex(data: &[u8]) -> String {
         .collect()
 }
 
-/// Look up the expected SHA-256 for `filename` inside a `SHA256SUMS` body.
-/// Each line is `<hex>  <name>` (a leading `*` on the name, from binary mode, is
-/// tolerated).
+// Look up the expected SHA-256 for `filename` inside a `SHA256SUMS` body.
+// Each line is `<hex>  <name>` (a leading `*` on the name, from binary mode, is
+// tolerated).
 fn expected_sha256(sha256sums: &str, filename: &str) -> Option<String> {
     for line in sha256sums.lines() {
         let mut parts = line.split_whitespace();
@@ -149,9 +143,7 @@ fn expected_sha256(sha256sums: &str, filename: &str) -> Option<String> {
     None
 }
 
-// --- archive extraction --------------------------------------------------------
-
-/// Extract the `hermes-decomp` binary bytes from the downloaded archive.
+// Extract the `hermes-decomp` binary bytes from the downloaded archive.
 #[cfg(not(windows))]
 fn extract_binary(archive: &[u8]) -> Res<Vec<u8>> {
     let decoder = flate2::read::GzDecoder::new(archive);
@@ -185,30 +177,35 @@ fn extract_binary(archive: &[u8]) -> Res<Vec<u8>> {
     Err(format!("`{BIN_NAME}.exe` not found in the downloaded archive").into())
 }
 
-/// Write the new binary to a sibling temp file, make it executable, then swap it
-/// into place atomically (handles the running-executable case on all platforms).
+// Stage the verified binary in a fresh temp file, then swap it into place.
+//
+// This function intentionally does NOT resolve the running executable's own
+// path: that lookup is documented as unsafe to trust for security-sensitive
+// decisions (it can be influenced through hard links, mount namespaces or
+// `/proc` manipulation). Locating and atomically replacing the running
+// executable is delegated entirely to `self_replace`, and the staging file is
+// created with `tempfile` (O_EXCL, unpredictable name), so no
+// attacker-influenced path is used to write or place the new binary.
 fn replace_running_binary(binary: &[u8]) -> Res<()> {
-    let current = std::env::current_exe()?;
-    let dir = current.parent().ok_or("cannot locate install directory")?;
-    let tmp = dir.join(format!(".hermes-decomp-update-{}", std::process::id()));
-    std::fs::write(&tmp, binary)?;
+    use std::io::Write;
+
+    let mut staged = tempfile::Builder::new()
+        .prefix("hermes-decomp-update-")
+        .tempfile()?;
+    staged.write_all(binary)?;
+    staged.flush()?;
+
+    let staged_path = staged.into_temp_path(); // removed on drop
 
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o755))?;
+        std::fs::set_permissions(&staged_path, std::fs::Permissions::from_mode(0o755))?;
     }
 
-    // self-replace swaps the currently running executable for `tmp`.
-    if let Err(e) = self_replace::self_replace(&tmp) {
-        let _ = std::fs::remove_file(&tmp);
-        return Err(e.into());
-    }
-    let _ = std::fs::remove_file(&tmp);
+    self_replace::self_replace(&staged_path)?;
     Ok(())
 }
-
-// --- public API ----------------------------------------------------------------
 
 pub struct UpdateInfo {
     pub current: String,

--- a/crates/hbc-decomp-cli/src/commands/update_cmd.rs
+++ b/crates/hbc-decomp-cli/src/commands/update_cmd.rs
@@ -177,25 +177,32 @@ fn extract_binary(archive: &[u8]) -> Res<Vec<u8>> {
     Err(format!("`{BIN_NAME}.exe` not found in the downloaded archive").into())
 }
 
-// Stage the verified binary in a fresh temp file, then swap it into place.
+// Stage the verified binary in a fresh file, then swap it into place.
 //
 // This function intentionally does NOT resolve the running executable's own
 // path: that lookup is documented as unsafe to trust for security-sensitive
 // decisions (it can be influenced through hard links, mount namespaces or
 // `/proc` manipulation). Locating and atomically replacing the running
-// executable is delegated entirely to `self_replace`, and the staging file is
-// created with `tempfile` (O_EXCL, unpredictable name), so no
-// attacker-influenced path is used to write or place the new binary.
+// executable is delegated entirely to `self_replace`. The staging file is
+// opened with `create_new` (O_EXCL), which fails rather than following a
+// pre-existing symlink at the path.
 fn replace_running_binary(binary: &[u8]) -> Res<()> {
     use std::io::Write;
 
-    let mut staged = tempfile::Builder::new()
-        .prefix("hermes-decomp-update-")
-        .tempfile()?;
-    staged.write_all(binary)?;
-    staged.flush()?;
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let mut staged_path = std::env::temp_dir();
+    staged_path.push(format!("hermes-decomp-update-{}-{nonce}", std::process::id()));
 
-    let staged_path = staged.into_temp_path(); // removed on drop
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&staged_path)?;
+    file.write_all(binary)?;
+    file.flush()?;
+    drop(file);
 
     #[cfg(unix)]
     {
@@ -203,8 +210,9 @@ fn replace_running_binary(binary: &[u8]) -> Res<()> {
         std::fs::set_permissions(&staged_path, std::fs::Permissions::from_mode(0o755))?;
     }
 
-    self_replace::self_replace(&staged_path)?;
-    Ok(())
+    let result = self_replace::self_replace(&staged_path);
+    let _ = std::fs::remove_file(&staged_path);
+    result.map_err(Into::into)
 }
 
 pub struct UpdateInfo {

--- a/crates/hbc-decomp-cli/src/commands/update_cmd.rs
+++ b/crates/hbc-decomp-cli/src/commands/update_cmd.rs
@@ -1,0 +1,176 @@
+use self_update::backends::github::Update;
+use self_update::update::ReleaseUpdate;
+
+const REPO_OWNER: &str = "SymbioticSec";
+const REPO_NAME: &str = "hermes-decomp";
+const BIN_NAME: &str = "hermes-decomp";
+const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+fn target_triple() -> &'static str {
+    if cfg!(target_os = "linux") {
+        if cfg!(target_arch = "x86_64") {
+            "linux-x86_64"
+        } else if cfg!(target_arch = "aarch64") {
+            "linux-arm64"
+        } else {
+            "linux"
+        }
+    } else if cfg!(target_os = "macos") {
+        if cfg!(target_arch = "aarch64") {
+            "macos-arm64"
+        } else if cfg!(target_arch = "x86_64") {
+            "macos-x86_64"
+        } else {
+            "macos"
+        }
+    } else if cfg!(target_os = "windows") {
+        if cfg!(target_arch = "x86_64") {
+            "windows-x86_64"
+        } else {
+            "windows"
+        }
+    } else {
+        "unknown"
+    }
+}
+
+fn build_updater(target_suffix: &str) -> Result<Box<dyn ReleaseUpdate>, Box<dyn std::error::Error>> {
+    let asset_name = format!("hermes-decomp-{}.{}", target_suffix, archive_ext());
+    let updater = Update::configure()
+        .repo_owner(REPO_OWNER)
+        .repo_name(REPO_NAME)
+        .bin_name(BIN_NAME)
+        .current_version(PKG_VERSION)
+        .target(&asset_name)
+        .show_download_progress(true)
+        .show_output(false)
+        .no_confirm(true)
+        .build()?;
+    Ok(updater)
+}
+
+fn archive_ext() -> &'static str {
+    if cfg!(target_os = "windows") { "zip" } else { "tar.gz" }
+}
+
+pub struct UpdateInfo {
+    pub current: String,
+    pub latest: String,
+    pub notes: Option<String>,
+    pub update_available: bool,
+}
+
+pub fn check() -> Result<UpdateInfo, Box<dyn std::error::Error>> {
+    let target = target_triple();
+    let updater = build_updater(target)?;
+    let latest = updater.get_latest_release()?;
+    let latest_raw = latest.name.trim_start_matches('v').to_string();
+    let latest_tag = normalize_semver(&latest_raw);
+    let current_tag = normalize_semver(PKG_VERSION);
+    let update_available = is_newer(&latest_raw, PKG_VERSION);
+    Ok(UpdateInfo {
+        current: current_tag,
+        latest: latest_tag,
+        notes: latest.body,
+        update_available,
+    })
+}
+
+pub fn install(version: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+    let target = target_triple();
+    let updater = if let Some(v) = version {
+        let v = v.trim_start_matches('v');
+        let asset_name = format!("hermes-decomp-{}.{}", target, archive_ext());
+        Update::configure()
+            .repo_owner(REPO_OWNER)
+            .repo_name(REPO_NAME)
+            .bin_name(BIN_NAME)
+            .current_version(PKG_VERSION)
+            .target_version_tag(v)
+            .target(&asset_name)
+            .show_download_progress(true)
+            .show_output(false)
+            .no_confirm(true)
+            .build()?
+    } else {
+        build_updater(target)?
+    };
+    let status = updater.update()?;
+    log::info!("Update status: `{}`", status);
+    println!("Downloaded and installed. Restart hermes-decomp to use the new version.");
+    println!("(self_update reported: {:?})", status);
+    Ok(())
+}
+
+fn is_newer(latest: &str, current: &str) -> bool {
+    parse_semver(latest) > parse_semver(current)
+}
+
+fn parse_semver(s: &str) -> Vec<u64> {
+    s.trim_start_matches('v')
+        .split(|c: char| c == '.' || c == '-' || c == '+')
+        .filter_map(|p| p.parse::<u64>().ok())
+        .collect()
+}
+
+fn normalize_semver(s: &str) -> String {
+    parse_semver(s)
+        .iter()
+        .map(u64::to_string)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+pub fn run(check_only: bool, install_now: bool, version: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let do_install = install_now || (!check_only && version.is_some());
+
+    if do_install {
+        if version.is_none() {
+            let info = check()?;
+            if !info.update_available {
+                println!("Already on the latest version ({}).", info.current);
+                return Ok(());
+            }
+            println!("Updating from v{} to v{}...", info.current, info.latest);
+            if let Some(notes) = info.notes.as_deref() {
+                println!("\nChangelog:\n{}", notes);
+            }
+        }
+        install(version.as_deref())?;
+        return Ok(());
+    }
+
+    let info = check()?;
+    if info.update_available {
+        println!("Update available: v{} -> v{}", info.current, info.latest);
+        if let Some(notes) = info.notes.as_deref() {
+            println!("\nChangelog:\n{}", notes);
+        }
+        println!("\nRun `hermes-decomp update --install` to upgrade.");
+    } else {
+        println!("Up to date (v{}).", info.current);
+    }
+    Ok(())
+}
+
+pub fn auto_check_on_startup() {
+    if std::env::var_os("HERMES_DECOMP_NO_UPDATE_CHECK").is_some() {
+        return;
+    }
+    let enabled = std::env::var("HERMES_DECOMP_UPDATE_CHECK")
+        .map(|v| !matches!(v.as_str(), "0" | "false" | "no" | "off"))
+        .unwrap_or(false);
+    if !enabled {
+        return;
+    }
+    std::thread::spawn(|| {
+        if let Ok(info) = check() {
+            if info.update_available {
+                eprintln!(
+                    "hermes-decomp v{} is available (you have v{}). Run `hermes-decomp update --install` to upgrade.",
+                    info.latest, info.current
+                );
+            }
+        }
+    });
+}

--- a/crates/hbc-decomp-cli/src/commands/update_cmd.rs
+++ b/crates/hbc-decomp-cli/src/commands/update_cmd.rs
@@ -35,7 +35,7 @@ fn target_triple() -> &'static str {
 }
 
 fn build_updater(target_suffix: &str) -> Result<Box<dyn ReleaseUpdate>, Box<dyn std::error::Error>> {
-    let asset_name = format!("hermes-decomp-{}.{}", target_suffix, archive_ext());
+    let asset_name = format!("{}.{}", target_suffix, archive_ext());
     let updater = Update::configure()
         .repo_owner(REPO_OWNER)
         .repo_name(REPO_NAME)
@@ -79,14 +79,14 @@ pub fn check() -> Result<UpdateInfo, Box<dyn std::error::Error>> {
 pub fn install(version: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
     let target = target_triple();
     let updater = if let Some(v) = version {
-        let v = v.trim_start_matches('v');
-        let asset_name = format!("hermes-decomp-{}.{}", target, archive_ext());
+        let tag = if v.starts_with('v') { v.to_string() } else { format!("v{}", v) };
+        let asset_name = format!("{}.{}", target, archive_ext());
         Update::configure()
             .repo_owner(REPO_OWNER)
             .repo_name(REPO_NAME)
             .bin_name(BIN_NAME)
             .current_version(PKG_VERSION)
-            .target_version_tag(v)
+            .target_version_tag(&tag)
             .target(&asset_name)
             .show_download_progress(true)
             .show_output(false)

--- a/crates/hbc-decomp-cli/src/commands/update_cmd.rs
+++ b/crates/hbc-decomp-cli/src/commands/update_cmd.rs
@@ -303,14 +303,18 @@ pub fn run(check_only: bool, install_now: bool, version: Option<String>) -> Res<
     }
 
     let info = check()?;
-    if info.update_available {
-        println!("Update available: v{} -> v{}", info.current, info.latest);
-        if let Some(notes) = info.notes.as_deref() {
-            println!("\nChangelog:\n{notes}");
+    println!("Current version: v{}", info.current);
+    println!("Latest release:  v{}", info.latest);
+    if let Some(notes) = info.notes.as_deref() {
+        let notes = notes.trim();
+        if !notes.is_empty() {
+            println!("\nChangelog (v{}):\n{notes}", info.latest);
         }
-        println!("\nRun `hermes-decomp update --install` to upgrade.");
+    }
+    if info.update_available {
+        println!("\nUpdate available. Run `hermes-decomp update --install` to upgrade.");
     } else {
-        println!("Up to date (v{}).", info.current);
+        println!("\nYou are up to date.");
     }
     Ok(())
 }

--- a/crates/hbc-decomp-cli/src/main.rs
+++ b/crates/hbc-decomp-cli/src/main.rs
@@ -18,6 +18,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     hbc_decomp::configure_thread_pool();
     let cli = Cli::parse();
 
+    commands::update_cmd::auto_check_on_startup();
+
     match cli.command {
         Command::Info {
             input,
@@ -405,6 +407,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let file = load_file(&input, layout, function_layout)?;
             let format = load_format(&file, format_version)?;
             commands::callgraph_cmd::run_callgraph(&file, &format, function, depth, dot)?;
+        }
+        Command::Update {
+            check,
+            install,
+            version,
+        } => {
+            commands::update_cmd::run(check, install, version)?;
         }
     }
 

--- a/crates/hbc-decomp-mcp/Cargo.toml
+++ b/crates/hbc-decomp-mcp/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 hbc-decomp = { path = "../hbc-decomp" }
-rmcp = { version = "0.8", features = ["server", "transport-io", "transport-streamable-http-server"] }
+rmcp = { version = "2", features = ["server", "transport-io", "transport-streamable-http-server"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/hbc-decomp-mcp/Cargo.toml
+++ b/crates/hbc-decomp-mcp/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "hbc-decomp-mcp"
-version = "0.1.6"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "MCP server exposing Hermes bytecode decompiler tools for AI assistants"
-repository = "https://github.com/SymbioticSec/hermes-decomp"
+repository.workspace = true
 
 [[bin]]
 name = "hermes-mcp"

--- a/crates/hbc-decomp-mcp/src/server.rs
+++ b/crates/hbc-decomp-mcp/src/server.rs
@@ -1,7 +1,7 @@
 use rmcp::ErrorData as McpError;
 use rmcp::{
     handler::server::{router::tool::ToolRouter, wrapper::Parameters},
-    model::{CallToolResult, Content, ServerCapabilities, ServerInfo},
+    model::{CallToolResult, ContentBlock, ServerCapabilities, ServerInfo},
     schemars, tool, tool_handler, tool_router, ServerHandler,
 };
 use serde::Deserialize;
@@ -246,7 +246,7 @@ impl HermesService {
             bytes,
             pipeline_ctx: None,
         });
-        Ok(CallToolResult::success(vec![Content::text(info)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(info)]))
     }
 
     #[tool(description = "Get file header info: version, function count, string count, file path.")]
@@ -260,7 +260,7 @@ impl HermesService {
                 file.header.function_count,
                 file.header.string_count,
             );
-            Ok(CallToolResult::success(vec![Content::text(info)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(info)]))
         })
     }
 
@@ -301,7 +301,7 @@ impl HermesService {
                 )
                 .map_err(|e| McpError::internal_error(format!("{e}"), None))?
             };
-            Ok(CallToolResult::success(vec![Content::text(code)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(code)]))
         })
     }
 
@@ -316,7 +316,7 @@ impl HermesService {
             loaded.ensure_pipeline()?;
             let pipeline = loaded.pipeline_ctx.as_ref().unwrap();
             let code = pipeline.generate_function_code(&loaded.file, params.function_id);
-            Ok(CallToolResult::success(vec![Content::text(code)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(code)]))
         })
     }
 
@@ -332,7 +332,7 @@ impl HermesService {
                 &opts,
             )
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-            Ok(CallToolResult::success(vec![Content::text(code)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(code)]))
         })
     }
 
@@ -354,7 +354,7 @@ impl HermesService {
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
             let json = serde_json::to_string_pretty(&ir)
                 .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-            Ok(CallToolResult::success(vec![Content::text(json)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
         })
     }
 
@@ -377,7 +377,7 @@ impl HermesService {
                 &options,
             )
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-            Ok(CallToolResult::success(vec![Content::text(asm)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(asm)]))
         })
     }
 
@@ -414,7 +414,7 @@ impl HermesService {
                     xref.function_id, name, xref.offset, xref.opcode
                 ));
             }
-            Ok(CallToolResult::success(vec![Content::text(output)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
         })
     }
 
@@ -445,7 +445,7 @@ impl HermesService {
                     m.module_id, m.function_id, name_str, m.dependencies, export_count
                 ));
             }
-            Ok(CallToolResult::success(vec![Content::text(output)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
         })
     }
 
@@ -459,7 +459,7 @@ impl HermesService {
             loaded.ensure_pipeline()?;
             let registry = &loaded.pipeline_ctx.as_ref().unwrap().registry;
             let tree = registry.get_dependency_tree(params.module_id, params.depth);
-            Ok(CallToolResult::success(vec![Content::text(tree.format(0))]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(tree.format(0))]))
         })
     }
 
@@ -534,7 +534,7 @@ impl HermesService {
                     }
                 }
             }
-            Ok(CallToolResult::success(vec![Content::text(output)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
         })
     }
 
@@ -546,7 +546,7 @@ impl HermesService {
             .map(|v| v.to_string())
             .collect::<Vec<_>>()
             .join(", ");
-        Ok(CallToolResult::success(vec![Content::text(format!(
+        Ok(CallToolResult::success(vec![ContentBlock::text(format!(
             "Supported Hermes bytecode versions: HBC 40-99.\nAvailable opcode tables: {list}"
         ))]))
     }
@@ -574,7 +574,7 @@ impl HermesService {
 
             let info = ClosureInfo::analyze(&stmts);
             if info.slots.is_empty() {
-                return Ok(CallToolResult::success(vec![Content::text(format!(
+                return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                     "Function {} has no closure variable slots.",
                     params.function_id
                 ))]));
@@ -600,7 +600,7 @@ impl HermesService {
                 };
                 output.push_str(&format!("  slot {slot}: {desc}\n"));
             }
-            Ok(CallToolResult::success(vec![Content::text(output)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
         })
     }
 
@@ -641,7 +641,7 @@ impl HermesService {
                     output.push_str(&format!("  ... and {} more\n", dead_count - 200));
                 }
             }
-            Ok(CallToolResult::success(vec![Content::text(output)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
         })
     }
 
@@ -655,7 +655,7 @@ impl HermesService {
         self.with_file(|loaded| {
             let offset = loaded.file.header.debug_info_offset;
             if offset == 0 || offset == u32::MAX {
-                return Ok(CallToolResult::success(vec![Content::text(
+                return Ok(CallToolResult::success(vec![ContentBlock::text(
                     "No debug info available in this bytecode file.",
                 )]));
             }
@@ -711,7 +711,7 @@ impl HermesService {
                 output.push_str("Debug info section exists but contains no data for this function.");
             }
 
-            Ok(CallToolResult::success(vec![Content::text(output)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
         })
     }
 
@@ -742,7 +742,7 @@ impl HermesService {
                 .unwrap_or_else(|| format!("f{}", params.function_id));
 
             let dot = hbc_decomp::ir::generate_dot(&cfg, &function_name);
-            Ok(CallToolResult::success(vec![Content::text(dot)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(dot)]))
         })
     }
 
@@ -768,7 +768,7 @@ impl HermesService {
                 })?;
             let function_id = module.function_id;
             let code = pipeline.generate_function_code(&loaded.file, function_id);
-            Ok(CallToolResult::success(vec![Content::text(code)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(code)]))
         })
     }
 
@@ -800,7 +800,7 @@ impl HermesService {
                 .unwrap_or_default();
 
             if module.exports.is_empty() {
-                return Ok(CallToolResult::success(vec![Content::text(format!(
+                return Ok(CallToolResult::success(vec![ContentBlock::text(format!(
                     "Module {}{} has no detected exports.",
                     params.module_id, name_str
                 ))]));
@@ -826,7 +826,7 @@ impl HermesService {
                     "  export \"{name}\" -> function {func_id} ({func_name})\n"
                 ));
             }
-            Ok(CallToolResult::success(vec![Content::text(output)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
         })
     }
 
@@ -854,7 +854,7 @@ impl HermesService {
             } else {
                 hbc_decomp::dump_table(&loaded.file, kind)
             };
-            Ok(CallToolResult::success(vec![Content::text(text)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(text)]))
         })
     }
 
@@ -874,7 +874,7 @@ impl HermesService {
                 params.dot,
             )
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-            Ok(CallToolResult::success(vec![Content::text(output)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(output)]))
         })
     }
 
@@ -893,7 +893,7 @@ impl HermesService {
                         None,
                     )
                 })?;
-            Ok(CallToolResult::success(vec![Content::text(banner)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(banner)]))
         })
     }
 }
@@ -901,12 +901,13 @@ impl HermesService {
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for HermesService {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            instructions: Some(
-                "Hermes bytecode decompiler for React Native apps (HBC 40-99). Load a .hbc file with load_file, then use decompile/disassemble/xref/module tools to analyze. Use decompile_function for quick single-function output, or decompile_function_full/decompile_module for full-quality analysis with IPA naming and ESM imports/exports. Structural inspection: dump_table (cjs-modules, regexp, obj-shapes, function-sources, string-kinds, sections, big-int, array-buffer), callgraph (caller->callee edges, optional DOT), and function_info (per-function metadata banner).".into()
-            ),
-            capabilities: ServerCapabilities::builder().enable_tools().build(),
-            ..Default::default()
-        }
+        // ServerInfo (InitializeResult) is #[non_exhaustive] in rmcp 2, so it
+        // cannot be built with a struct literal; set fields on a default value.
+        let mut info = ServerInfo::default();
+        info.instructions = Some(
+            "Hermes bytecode decompiler for React Native apps (HBC 40-99). Load a .hbc file with load_file, then use decompile/disassemble/xref/module tools to analyze. Use decompile_function for quick single-function output, or decompile_function_full/decompile_module for full-quality analysis with IPA naming and ESM imports/exports. Structural inspection: dump_table (cjs-modules, regexp, obj-shapes, function-sources, string-kinds, sections, big-int, array-buffer), callgraph (caller->callee edges, optional DOT), and function_info (per-function metadata banner).".into()
+        );
+        info.capabilities = ServerCapabilities::builder().enable_tools().build();
+        info
     }
 }

--- a/crates/hbc-decomp/Cargo.toml
+++ b/crates/hbc-decomp/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "hbc-decomp"
-version = "0.1.6"
-edition = "2021"
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Hermes bytecode (.hbc) decompiler library for React Native apps"
-repository = "https://github.com/SymbioticSec/hermes-decomp"
+repository.workspace = true
 keywords = ["hermes", "bytecode", "decompiler", "react-native", "reverse-engineering"]
 categories = ["development-tools", "parser-implementations"]
 build = "build.rs"

--- a/crates/hbc-decomp/Cargo.toml
+++ b/crates/hbc-decomp/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["development-tools", "parser-implementations"]
 build = "build.rs"
 
 [dependencies]
-bincode = "1.3"
+rmp-serde = "1"
 colored = "3.1.1"
 env_logger = "0.11.9"
 log = "0.4.29"

--- a/crates/hbc-decomp/src/pipeline/cache.rs
+++ b/crates/hbc-decomp/src/pipeline/cache.rs
@@ -143,11 +143,11 @@ impl PipelineContext {
 fn try_load(path: &Path, want: &CacheHeader) -> Option<PipelineContext> {
     let f = std::fs::File::open(path).ok()?;
     let mut reader = BufReader::new(f);
-    let got: CacheHeader = bincode::deserialize_from(&mut reader).ok()?;
+    let got: CacheHeader = rmp_serde::decode::from_read(&mut reader).ok()?;
     if !got.matches(want) {
         return None;
     }
-    let snap: PipelineSnapshot = bincode::deserialize_from(&mut reader).ok()?;
+    let snap: PipelineSnapshot = rmp_serde::decode::from_read(&mut reader).ok()?;
     Some(PipelineContext::from_snapshot(snap))
 }
 
@@ -190,8 +190,8 @@ mod tests {
         };
 
         // Serialize the snapshot and read it back.
-        let bytes = bincode::serialize(&ctx.to_snapshot()).expect("serialize");
-        let snap: PipelineSnapshot = bincode::deserialize(&bytes).expect("deserialize");
+        let bytes = rmp_serde::to_vec(&ctx.to_snapshot()).expect("serialize");
+        let snap: PipelineSnapshot = rmp_serde::from_slice(&bytes).expect("deserialize");
         let restored = PipelineContext::from_snapshot(snap);
 
         let m = restored.registry.modules.get(&7).expect("module preserved");
@@ -227,9 +227,9 @@ fn try_save(path: &Path, header: &CacheHeader, ctx: &PipelineContext) -> std::io
     {
         let f = std::fs::File::create(&tmp)?;
         let mut writer = BufWriter::new(f);
-        let map_err = |e: bincode::Error| std::io::Error::other(e.to_string());
-        bincode::serialize_into(&mut writer, header).map_err(map_err)?;
-        bincode::serialize_into(&mut writer, &ctx.to_snapshot()).map_err(map_err)?;
+        let map_err = |e: rmp_serde::encode::Error| std::io::Error::other(e.to_string());
+        rmp_serde::encode::write(&mut writer, header).map_err(map_err)?;
+        rmp_serde::encode::write(&mut writer, &ctx.to_snapshot()).map_err(map_err)?;
         use std::io::Write;
         writer.flush()?;
     }


### PR DESCRIPTION
## Summary

Add a built-in update mechanism to `hermes-decomp` so users can check for and install new versions directly from the CLI without visiting GitHub. Introduces the `update` subcommand backed by GitHub releases, plus an optional background check that prints a notice on startup when a newer version is available.

## Changes

### New Features
- `hermes-decomp update --check` prints the latest release version, changelog, and whether an update is available
- `hermes-decomp update --install` downloads the correct platform archive from GitHub releases and replaces the current binary in-place
- `hermes-decomp update --version v0.1.6 --install` installs a specific version
- Optional startup check: set `HERMES_DECOMP_UPDATE_CHECK=1` to get a one-line notice on launch when a newer version exists
- Set `HERMES_DECOMP_NO_UPDATE_CHECK=1` to suppress the startup check entirely

### Technical Details
- Uses the `self_update` crate with its GitHub releases backend
- Platform detection covers `linux-x86_64`, `linux-arm64`, `macos-arm64`, `macos-x86_64`, and `windows-x86_64`
- Asset matching relies on `self_update`'s substring matching against release asset filenames
- SemVer comparison handles `v`-prefixed tags, pre-release suffixes, and two- or three-component versions
- Startup check runs in a background thread so it never blocks CLI startup
- Version, edition, license, and repository fields for all workspace crates now inherit from `[workspace.package]` in the root `Cargo.toml` (single source of truth)

### Files Modified
- `crates/hbc-decomp-cli/src/commands/update_cmd.rs` - New module: `check()`, `install()`, `run()`, `auto_check_on_startup()`, platform detection, SemVer parsing
- `crates/hbc-decomp-cli/src/commands/mod.rs` - Expose `update_cmd` module
- `crates/hbc-decomp-cli/src/cli_args.rs` - Add `Update` variant with `--check`, `--install`, `--version` flags
- `crates/hbc-decomp-cli/src/main.rs` - Wire up `update` command, call `auto_check_on_startup()` before dispatch
- `crates/hbc-decomp-cli/Cargo.toml` - Add `self_update` dependency, inherit workspace metadata
- `crates/hbc-decomp/Cargo.toml` - Inherit workspace metadata
- `crates/hbc-decomp-mcp/Cargo.toml` - Inherit workspace metadata
- `Cargo.toml` - Add `self_update` to workspace dependencies, define `[workspace.package]`

## Usage

```bash
# Check if a newer version exists
hermes-decomp update --check

# Update to the latest release
hermes-decomp update --install

# Install a specific version
hermes-decomp update --version v0.1.6 --install

# Enable startup update check (opt-in)
export HERMES_DECOMP_UPDATE_CHECK=1
hermes-decomp tui bundle.hbc
# → "hermes-decomp v0.1.7 is available (you have v0.1.6). Run `hermes-decomp update --install` to upgrade."
```

## Demo
<img width="1276" height="1097" alt="hermes-update" src="https://github.com/user-attachments/assets/1283a9b1-1bf6-4859-ad60-e045fe1bc67e" />


## Testing

1. `cargo build --release`
2. `./target/release/hermes-decomp update --check` - prints latest version and changelog
3. `./target/release/hermes-decomp update --version v0.1.6 --install` - downloads and installs v0.1.6
4. `HERMES_DECOMP_UPDATE_CHECK=1 ./target/release/hermes-decomp --help` - verify startup notice appears (when behind latest)
5. `HERMES_DECOMP_NO_UPDATE_CHECK=1 ./target/release/hermes-decomp --help` - verify no notice appears
